### PR TITLE
TAUR-1217 Fix grok pipeline package install

### DIFF
--- a/grok/grok/pipeline/scripts/rpm-creator/post_install_grok
+++ b/grok/grok/pipeline/scripts/rpm-creator/post_install_grok
@@ -49,4 +49,7 @@ fi
 
 pip install psutil==1.2.1
 
+# Install requirements.txt
+pip install -r requirements.txt
+
 python setup.py develop --install-dir=lib/python2.7/site-packages --script-dir=bin

--- a/infrastructure/ami-tools/Rakefile
+++ b/infrastructure/ami-tools/Rakefile
@@ -27,12 +27,14 @@
 CENTOS6_CONFIG="ami-configurations/centos6.json"
 GROK_PIPELINE_CONFIG="ami-configurations/grok-pipeline.json"
 GROK_PLUMBING_CONFIG="ami-configurations/grok-plumbing.json"
+INFRASTRUCTURE_128GB_CONFIG="ami-configurations/infrastructure-base-128gb.json"
 INFRASTRUCTURE_CONFIG="ami-configurations/infrastructure-base.json"
 WEB_CONFIG="ami-configurations/salt-webserver.json"
 
 epel_rpm = "epel-release-6-8.noarch.rpm"
 epel_rpm_url = "http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm"
 s3_yum_plugin_rpm = "yum-s3-0.2.4-1.noarch.rpm"
+s3_yum_plugin_url = "https://s3-us-west-2.amazonaws.com/yum.groksolutions.com/s3/thirdparty/yum-s3-0.2.4-1.noarch.rpm"
 secretsauce_repo_f = "repos/secretsauce.repo"
 
 task :help do
@@ -44,6 +46,8 @@ task :clean => [:cleanup]
 task :default => [:help]
 task :grok => [:bake_grok_pipeline]
 task :h => [:help]
+task :i => [:bake_infrastructure]
+task :inf128 => [:bake_infrastructure_128gb]
 task :plumbing => [:bake_grok_plumbing]
 task :webserver => [:bake_webserver]
 
@@ -80,9 +84,18 @@ end
 
 desc "Validate Infrastructure configuration"
 task :validate_infrastructure => [:products_sha,
+                                  :grok_repos,
                                   :salt_bootstrap,
                                   :yum_plugin] do
   sh %{ packer validate #{INFRASTRUCTURE_CONFIG} }
+end
+
+desc "Validate Infrastructure 128GB configuration"
+task :validate_infrastructure_128gb => [:products_sha,
+                                        :grok_repos,
+                                        :salt_bootstrap,
+                                        :yum_plugin] do
+  sh %{ packer validate #{INFRASTRUCTURE_128GB_CONFIG} }
 end
 
 desc "Validate Webserver packer configuration"
@@ -109,7 +122,6 @@ task :bake_grok_pipeline => [:products_sha,
                              :epel_repo,
                              :grok_repos,
                              :validate_grok_pipeline ] do
-  # sh %{ packer build #{GROK_PIPELINE_CONFIG} }
   sh %{ packer build -var 'grok_install_manifest=#{ENV["GROK_INSTALL_MANIFEST"]}' \
        -var 'ami_name=#{ENV["AMI_NAME"]}' #{GROK_PIPELINE_CONFIG} }
 end
@@ -125,12 +137,23 @@ task :bake_grok_plumbing => [:products_sha,
 end
 
 desc "Bake a new Infrastructure AMI"
-task :bake_infrastructure => [:products_sha,
-                              :yum_plugin,
+task :bake_infrastructure => [:grok_repos,
+                              :products_sha,
                               :salt_bootstrap,
                               :secretsauce_repo,
-                              :validate_infrastructure ] do
+                              :validate_infrastructure,
+                              :yum_plugin ] do
   sh %{ packer build #{INFRASTRUCTURE_CONFIG} }
+end
+
+desc "Bake a new 128GB Infrastructure AMI"
+task :bake_infrastructure_128gb => [:grok_repos,
+                                    :products_sha,
+                                    :salt_bootstrap,
+                                    :secretsauce_repo,
+                                    :validate_infrastructure_128gb,
+                                    :yum_plugin ] do
+  sh %{ packer build #{INFRASTRUCTURE_128GB_CONFIG} }
 end
 
 desc "Bake a new HVM webserver AMI"
@@ -147,8 +170,10 @@ end
 
 # Get the s3 yum plugin
 file s3_yum_plugin_rpm do
-  puts "Downloading #{s3_yum_plugin_rpm}"
-  sh %{ wget --no-check-certificate https://s3-us-west-2.amazonaws.com/yum.groksolutions.com/s3/thirdparty/yum-s3-0.2.4-1.noarch.rpm }
+  unless File.exist?(s3_yum_plugin_rpm)
+    puts "Downloading #{s3_yum_plugin_rpm}"
+    sh %{ wget --no-check-certificate #{s3_yum_plugin_url} }
+  end
 end
 
 desc "Download the yum s3 plugin"
@@ -156,8 +181,10 @@ task :yum_plugin => [s3_yum_plugin_rpm]
 
 # Get the EPEL installer rpm for 6.5
 file epel_rpm do
-  puts "Downloading #{epel_rpm_url}"
-  sh %{ wget --no-check-certificate #{epel_rpm_url} }
+  unless File.exist?(epel_rpm)
+    puts "Downloading #{epel_rpm_url}"
+    sh %{ wget --no-check-certificate #{epel_rpm_url} }
+  end
 end
 
 desc "Download the epel yum plugin"
@@ -166,8 +193,10 @@ task :epel_repo => [epel_rpm]
 # Get salt bootstrap
 desc "Download the latest Salt bootstrap.sh script"
 task :salt_bootstrap do
-  sh %{ wget --no-check-certificate -O - https://bootstrap.saltstack.com > bootstrap-salt.sh }
-  sh %{ chmod +x bootstrap-salt.sh }
+  unless File.exist?("bootstrap-salt.sh")
+    sh %{ wget --no-check-certificate -O - https://bootstrap.saltstack.com > bootstrap-salt.sh }
+    sh %{ chmod +x bootstrap-salt.sh }
+  end
 end
 
 # Cleanups
@@ -204,7 +233,9 @@ end
 # in two places
 desc "Copy the secretsauce repo from the saltcellar"
 task :secretsauce_repo do
-  sh %{ rsync ../saltcellar/yum-numenta-secret-sauce/files/secretsauce.repo repos/secretsauce.repo }
+  unless File.exist?("repos/secretsauce.repo")
+    sh %{ rsync ../saltcellar/yum-numenta-secret-sauce/files/secretsauce.repo repos/secretsauce.repo }
+  end
 end
 
 # Copy the grok repos from the saltcellar so we aren't maintaining them

--- a/infrastructure/ami-tools/ami-configurations/infrastructure-base-128gb.json
+++ b/infrastructure/ami-tools/ami-configurations/infrastructure-base-128gb.json
@@ -1,0 +1,130 @@
+{
+  "builders": [
+    {
+      "ami_description": "Numenta infrastructure base - CentOS 6.5 + 128GB root + SaltStack solo",
+      "ami_name": "numenta-infrastructure-saltstack-128GB-{{isotime | clean_ami_name}}",
+      "instance_type": "m3.large",
+      "region": "us-west-2",
+      "source_ami": "ami-ef4e6adf",
+      "ssh_port": 22,
+      "ssh_timeout": "3m",
+      "ssh_username": "root",
+      "tags": {
+        "OS_Version": "CentOS",
+        "Release": "6.5"
+      },
+      "ami_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "delete_on_termination" : true,
+          "volume_size": 128
+        }
+      ],
+      "type": "amazon-ebs"
+    }
+  ],
+  "provisioners": [
+    {
+      "destination": "/tmp/products.sha",
+      "source": "products.sha",
+      "type": "file"
+    },
+    {
+      "destination": "/tmp/secretsauce.repo",
+      "source": "repos/secretsauce.repo",
+      "type": "file"
+    },
+    {
+      "destination": "/tmp/grok-development.repo",
+      "source": "repos/grok-development.repo",
+      "type": "file"
+    },
+    {
+      "destination": "/tmp/nta-carbonite.repo",
+      "source": "repos/nta-carbonite.repo",
+      "type": "file"
+    },
+    {
+      "destination": "/tmp/nta-thirdparty.repo",
+      "source": "repos/nta-thirdparty.repo",
+      "type": "file"
+    },
+    {
+      "destination": "/tmp/bootstrap-salt.sh",
+      "source": "bootstrap-salt.sh",
+      "type": "file"
+    },
+    {
+      "destination": "/tmp/epel.repo",
+      "source": "repos/epel.repo",
+      "type": "file"
+    },
+    {
+      "destination": "/tmp/RPM-GPG-KEY-EPEL-6",
+      "source": "repos/RPM-GPG-KEY-EPEL-6",
+      "type": "file"
+    },
+    {
+      "destination": "/tmp/yum-s3-0.2.4-1.noarch.rpm",
+      "source": "yum-s3-0.2.4-1.noarch.rpm",
+      "type": "file"
+    },
+    {
+      "inline": [
+        "echo 'Sleeping for 30s, waiting for system to settle down.'",
+        "sleep 30",
+        "mkdir -p /etc/numenta",
+        "mkdir -p /srv/salt",
+        "echo",
+        "echo Engraving products SHA and build timestamp into AMI",
+        "echo",
+        "mv /tmp/products.sha /etc/numenta",
+        "date > /etc/numenta/build.time"
+      ],
+      "type": "shell"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/create-numenta-users"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/zap-centos-nonessentials"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/install-salt"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/set-salt-output-state-to-mixed"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/install-epel-repo-6.5"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/configure-infrastructure-ami"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/run-ami-tests"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/cleanup-infrastructure-ami"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/cleanup-image"
+    },
+    {
+      "inline": [
+        "echo 'df:'",
+        "df -h"
+      ],
+      "type": "shell"
+    }
+  ]
+}

--- a/infrastructure/ami-tools/packer-scripts/configure-grok-pipeline-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-grok-pipeline-ami
@@ -87,6 +87,9 @@ install-prerequisites-and-update-repos() {
 
   yum remove -y numenta-infrastructure-common grok-updater
   yum install -y numenta-infrastructure-python
+
+  # Ensure our pip is current
+  pip install --upgrade pip
 }
 
 run-salt() {

--- a/infrastructure/ami-tools/packer-scripts/configure-grok-plumbing-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-grok-plumbing-ami
@@ -41,6 +41,7 @@ install-prerequisites-and-update-repos() {
   echo "Cleaning up stale yum data..."
   yum clean all
 
+  # If you install these before installing yum-s3, yum will crash on start.
   for repo in grok-development.repo \
               grok-release-candidates.repo \
               grok-releases.repo \


### PR DESCRIPTION
* Ensure pip version is current on the AMI
* Add warning about installing yum-s3 before s3-backed repo files. Doing this in the wrong order breaks yum, so give people an explicit warning so they don't get to find that out the hard way.
* Rakefile cleanups
    * Add grok_repos dependency to validate stanzas so they don't choke when run in a fresh checkout
    * Don't bother to re-download yum s3 plugin if it is present
    * Don't download bootstrap-salt.sh if it is already present
    * Don't download epel rpm if it is already present
    * Replace hardcoded url for yum s3 plugin with a variable
* Run pip install -r requirements.txt in grok RPM postinstall script