### PR TITLE
TAUR-1217 Fix rpm versions

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -12,7 +12,7 @@ To package infrastructure directory:
     python setup.py sdist
 
 To install infrastructure:
- 
+
     python setup.py install
 
 
@@ -26,3 +26,10 @@ This directory contains scripts for creating AMIs.
 This directory contains salt formulas for installing packages
 required for GROK, modifying dot files, user management and
 installation of development tools as per requirements.
+
+`create-numenta-rpm`
+--------------------
+create-numenta-rpm is a helper script used to check out repositories and
+create RPM files from them using fpm. For ease of use with jenkins, it will
+set the base version of the RPM to the value of the RELEASE_VERSION
+environment variable unless overridden by the `--base-version` argument.

--- a/infrastructure/infrastructure/create-grok-rpm
+++ b/infrastructure/infrastructure/create-grok-rpm
@@ -37,7 +37,7 @@ time ./create-numenta-rpm --rpm-flavor grok \
   --rpm-name nta-products-grok \
   --postinstall-script "${reporoot}/grok/grok/pipeline/scripts/rpm-creator/post_install_grok" \
   --cleanup-script grok/grok/pipeline/scripts/rpm-creator/clean-grok-tree-for-packaging \
-  --base-version 1.7.0 \
+  --base-version 1.7.1 \
   --whitelist grok \
   --whitelist htmengine \
   --whitelist install-grok.sh \

--- a/infrastructure/infrastructure/create-grok-rpm
+++ b/infrastructure/infrastructure/create-grok-rpm
@@ -37,7 +37,6 @@ time ./create-numenta-rpm --rpm-flavor grok \
   --rpm-name nta-products-grok \
   --postinstall-script "${reporoot}/grok/grok/pipeline/scripts/rpm-creator/post_install_grok" \
   --cleanup-script grok/grok/pipeline/scripts/rpm-creator/clean-grok-tree-for-packaging \
-  --base-version 1.7.1 \
   --whitelist grok \
   --whitelist htmengine \
   --whitelist install-grok.sh \

--- a/infrastructure/infrastructure/create-numenta-rpm
+++ b/infrastructure/infrastructure/create-numenta-rpm
@@ -66,9 +66,7 @@ def parseCLA():
 
   parser = argparse.ArgumentParser(description="Create a products RPM")
 
-  defaultVersion = os.environ.get("RELEASE_VERSION")
-  if not defaultVersion:
-    defaultVersion = "1.7.1"
+  defaultVersion = os.environ.get("RELEASE_VERSION", "1.7.1")
 
   parser.add_argument("--artifact",
                       action="append",

--- a/infrastructure/infrastructure/create-numenta-rpm
+++ b/infrastructure/infrastructure/create-numenta-rpm
@@ -42,7 +42,7 @@ from infrastructure.utilities import git
 from infrastructure.utilities import logger as log
 from infrastructure.utilities import rpm
 from infrastructure.utilities.exceptions import InvalidParametersError
-from infrastructure.utilities.path import ( 
+from infrastructure.utilities.path import (
   changeToWorkingDir,
   purgeDirectory,
   rmrf)
@@ -82,7 +82,7 @@ def parseCLA():
   parser.add_argument("--base-version",
                       dest="baseVersion",
                       help="Base version number to use",
-                      default="1.7")
+                      default="1.7.1")
 
   parser.add_argument("--build-script",
                       action="append",

--- a/infrastructure/infrastructure/create-numenta-rpm
+++ b/infrastructure/infrastructure/create-numenta-rpm
@@ -66,6 +66,10 @@ def parseCLA():
 
   parser = argparse.ArgumentParser(description="Create a products RPM")
 
+  defaultVersion = os.environ.get("RELEASE_VERSION")
+  if not defaultVersion:
+    defaultVersion = "1.7.1"
+
   parser.add_argument("--artifact",
                       action="append",
                       dest="artifacts",
@@ -82,7 +86,7 @@ def parseCLA():
   parser.add_argument("--base-version",
                       dest="baseVersion",
                       help="Base version number to use",
-                      default="1.7.1")
+                      default=defaultVersion)
 
   parser.add_argument("--build-script",
                       action="append",
@@ -359,7 +363,7 @@ def setPythonPath(environment, productsDirectory):
     Set any extra pythonpath.
 
     @environment - current environment variables.
-    @param productsDirectory - products direcotry path.
+    @param productsDirectory - products directory path.
   """
   pythonpath = ""
   g_logger.debug("Previous: %s", pythonpath)
@@ -376,7 +380,7 @@ def cleanScripts(productsDirectory, environment):
   """
     Cleans the grok directory before packaging.
 
-    @param productsDirectory - products direcotry path
+    @param productsDirectory - products directory path
                                to run cleanup scripts.
   """
   g_logger.info("Running cleanup scripts...")
@@ -396,7 +400,7 @@ def purgeBlacklistedStuff(productsDirectory):
   """
     Purges anything not whitelisted.
 
-    @param productsDirectory - products direcotry path
+    @param productsDirectory - products directory path
                                to remove blacklisted stuff.
   """
   g_logger.info("Purge anything not whitelisted.")


### PR DESCRIPTION
We use the commit count as the rpm release version, so when we switched to the numenta-apps repo, we started generating rpms that had lower release versions, and yum assumed they were outdated.

Bumping the rpm version to 1.7.1 to get yum to see that newer rpms are in fact newer.