### PR TITLE
TAUR-1228 Update nta-yum repo files to not require S3 credentials

### DIFF
--- a/infrastructure/ami-tools/repos/nta-carbonite.repo
+++ b/infrastructure/ami-tools/repos/nta-carbonite.repo
@@ -1,6 +1,5 @@
 [nta-carbonite]
 name=nta-carbonite
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/carbonite
+baseurl=http://public.numenta.com/yum/carbonite
 gpgcheck=0
 priority=1
-s3_enabled=1

--- a/infrastructure/ami-tools/repos/nta-thirdparty.repo
+++ b/infrastructure/ami-tools/repos/nta-thirdparty.repo
@@ -1,6 +1,5 @@
 [nta-thirdparty]
 name=nta-thirdparty
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/thirdparty
+baseurl=http://public.numenta.com/yum/thirdparty
 gpgcheck=0
 priority=1
-s3_enabled=1

--- a/infrastructure/saltcellar/grok-plumbing/files/repos/grok-development.repo
+++ b/infrastructure/saltcellar/grok-plumbing/files/repos/grok-development.repo
@@ -1,13 +1,11 @@
 [grok-noarch]
 name=Grok Noarch repo
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/noarch
+baseurl=http://public.numenta.com/yum/noarch
 gpgcheck=0
 priority=1
-s3_enabled=1
 
 [grok-x86-64]
 name=Grok x86-64 Repository
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/x86_64
+baseurl=http://public.numenta.com/yum/x86_64
 gpgcheck=0
 priority=1
-s3_enabled=1

--- a/infrastructure/saltcellar/grok-plumbing/files/repos/grok-release-candidates.repo
+++ b/infrastructure/saltcellar/grok-plumbing/files/repos/grok-release-candidates.repo
@@ -1,6 +1,5 @@
 [grok-release-candidates]
 name=Release-Candidate RPMs for Grok
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/release-candidates
+baseurl=http://public.numenta.com/yum/release-candidates
 gpgcheck=0
 priority=1
-s3_enabled=1

--- a/infrastructure/saltcellar/grok-plumbing/files/repos/grok-releases.repo
+++ b/infrastructure/saltcellar/grok-plumbing/files/repos/grok-releases.repo
@@ -1,6 +1,5 @@
 [grok-releases]
 name=Grok public releases repository
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/releases
+baseurl=http://public.numenta.com/yum/releases
 gpgcheck=0
 priority=1
-s3_enabled=1

--- a/infrastructure/saltcellar/grok-plumbing/files/repos/marketplace-only.repo
+++ b/infrastructure/saltcellar/grok-plumbing/files/repos/marketplace-only.repo
@@ -1,6 +1,5 @@
 [marketplace-only]
 name=Grok Marketplace RPMs
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/marketplace-only
+baseurl=http://public.numenta.com/yum/marketplace-only
 gpgcheck=0
 priority=1
-s3_enabled=1

--- a/infrastructure/saltcellar/nta-yum/files/nta-carbonite.repo
+++ b/infrastructure/saltcellar/nta-yum/files/nta-carbonite.repo
@@ -1,6 +1,5 @@
 [nta-carbonite]
 name=Numenta Carbonite Repository
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/carbonite
+baseurl=http://public.numenta.com/yum/carbonite
 gpgcheck=0
 priority=1
-s3_enabled=1

--- a/infrastructure/saltcellar/nta-yum/files/nta-thirdparty.repo
+++ b/infrastructure/saltcellar/nta-yum/files/nta-thirdparty.repo
@@ -1,6 +1,5 @@
 [nta-thirdparty]
 name=Numenta Thirdparty repository
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/thirdparty
+baseurl=http://public.numenta.com/yum/thirdparty
 gpgcheck=0
 priority=1
-s3_enabled=1

--- a/infrastructure/saltcellar/role-grok/files/repos/grok-development.repo
+++ b/infrastructure/saltcellar/role-grok/files/repos/grok-development.repo
@@ -1,13 +1,11 @@
 [grok-noarch]
 name=grok-noarch
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/noarch
+baseurl=http://public.numenta.com/yum/noarch
 gpgcheck=0
 priority=1
-s3_enabled=1
 
 [grok-x86-64]
 name=grok-x86-64
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/x86_64
+baseurl=http://public.numenta.com/yum/x86_64
 gpgcheck=0
 priority=1
-s3_enabled=1

--- a/infrastructure/saltcellar/role-grok/files/repos/grok-release-candidates.repo
+++ b/infrastructure/saltcellar/role-grok/files/repos/grok-release-candidates.repo
@@ -1,6 +1,5 @@
 [grok-release-candidates]
 name=grok-release-candidates
-baseurl=http://yum.groksolutions.com.s3.amazonaws.com/s3/release-candidates
+baseurl=http://public.numenta.com/yum/release-candidates
 gpgcheck=0
 priority=1
-s3_enabled=1


### PR DESCRIPTION
* Updated ami-tools/repos
* Updated salt formulas:
    * Updated grok-plumbing
    * Updated nta-yum
    * Updated role-grok

public.numenta.com points to public.numenta.com.s3-website-us-west-2.amazonaws.com. This will make future updates a lot easier since we can redirect to new hosting without having to change the repo files on existing machines.
