### PR TITLE
HOTIFIX Update settings to fabric.api.run so we can catch errors properly

### DIFF
--- a/infrastructure/infrastructure/utilities/ssh.py
+++ b/infrastructure/infrastructure/utilities/ssh.py
@@ -93,6 +93,10 @@ def runCommandBySSH(dnsName,
   if sshKeyFile:
     kwargs["key_filename"] = sshKeyFile
 
+  # Force fabric not to abort if the command fails or we won't be able
+  # to retry
+  kwargs["warn_only"] = True
+
   with settings(**kwargs):
     logger.debug("Running %s on %s as %s", command, dnsName, user)
     tries = 0


### PR DESCRIPTION
If warn_only isn't explicitly set to true, fabric.api.run fails so hard we can't check the command exit code, which breaks our retry logic.

This was causing our instance start script to sporadically fail during boot even though we had set it to retry the startup scripts.
