### PR TITLE
Explicitly raise a custom exception if required APPLICATION_CONFIG_PA…

### DIFF
--- a/htmengine/README.md
+++ b/htmengine/README.md
@@ -19,8 +19,8 @@ First, install `nta.utils`.  Then, to install `htmengine`:
 Environment Variables
 ---------------------
 
-`APPLICATION_CONFIG_PATH`: directory path where active application configuration
-files are located
+`APPLICATION_CONFIG_PATH` **(REQUIRED)**: Directory path where active
+application-specific configuration files are located.
 
 
 Usage

--- a/htmengine/htmengine/__init__.py
+++ b/htmengine/htmengine/__init__.py
@@ -10,6 +10,13 @@ __version__ = distribution.version # See setup.py for constant
 HTMENGINE_HOME = distribution.location
 
 def raiseExceptionOnMissingRequiredApplicationConfigPath(fn):
+  """ Decorator to explicitly raise an ApplicationNotConfiguredError exception
+  in the event that the required APPLICATION_CONFIG_PATH environment variable
+  is not set.
+
+  :param fn: Function
+  :returns: Wrapped function
+  """
   @wraps(fn)
   def wrapper(*args, **kwargs):
     if "APPLICATION_CONFIG_PATH" not in os.environ:

--- a/htmengine/htmengine/__init__.py
+++ b/htmengine/htmengine/__init__.py
@@ -1,8 +1,23 @@
 import os
+from functools import wraps
 from pkg_resources import get_distribution
+from htmengine.exceptions import ApplicationNotConfiguredError
 
 distribution = get_distribution(__name__)
 
 __version__ = distribution.version # See setup.py for constant
 
 HTMENGINE_HOME = distribution.location
+
+def raiseExceptionOnMissingRequiredApplicationConfigPath(fn):
+  @wraps(fn)
+  def wrapper(*args, **kwargs):
+    if "APPLICATION_CONFIG_PATH" not in os.environ:
+      raise ApplicationNotConfiguredError("Required `APPLICATION_CONFIG_PATH` "
+                                          "not set in environment.  See %s for"
+                                          " details" % os.path.join(
+                                            HTMENGINE_HOME, "README.md"))
+
+    return fn(*args, **kwargs)
+
+  return wrapper

--- a/htmengine/htmengine/exceptions.py
+++ b/htmengine/htmengine/exceptions.py
@@ -28,6 +28,11 @@ class ObjectNotFoundError(HTMEngineError):
 
 
 
+class ApplicationNotConfiguredError(HTMEngineError, KeyError):
+  pass
+
+
+
 class ObjectAlreadyExistsBase(HTMEngineError):
   """ Base exception class for reporting metric/models that
   already exist; the `uid` attribute is used to report the unique id of the

--- a/htmengine/htmengine/model_swapper/__init__.py
+++ b/htmengine/htmengine/model_swapper/__init__.py
@@ -22,6 +22,7 @@
 import os
 
 from nta.utils.config import Config
+from htmengine import raiseExceptionOnMissingRequiredApplicationConfigPath
 
 
 
@@ -36,8 +37,10 @@ class ModelSwapperConfig(Config):
   CONFIG_NAME = "model-swapper.conf"
 
 
+  @raiseExceptionOnMissingRequiredApplicationConfigPath
   def __init__(self):
     super(ModelSwapperConfig, self).__init__(
       self.CONFIG_NAME,
-      os.environ.get("APPLICATION_CONFIG_PATH"))
+      os.environ["APPLICATION_CONFIG_PATH"]
+    )
 

--- a/htmengine/htmengine/runtime/anomaly_service.py
+++ b/htmengine/htmengine/runtime/anomaly_service.py
@@ -41,7 +41,8 @@ from htmengine import htmengineerrno
 from htmengine.exceptions import (ObjectNotFoundError,
                                   MetricNotActiveError,
                                   MetricNotMonitoredError)
-from htmengine import repository
+from htmengine import (raiseExceptionOnMissingRequiredApplicationConfigPath,
+                       repository)
 from htmengine.repository import retryOnTransientErrors, schema
 from htmengine.repository.queries import MetricStatus
 from htmengine.model_swapper.model_swapper_interface import (
@@ -57,7 +58,9 @@ from nta.utils.config import Config
 
 
 
-config = Config("application.conf", os.environ.get("APPLICATION_CONFIG_PATH"))
+
+config = raiseExceptionOnMissingRequiredApplicationConfigPath(Config)(
+  "application.conf", os.environ["APPLICATION_CONFIG_PATH"])
 
 
 

--- a/htmengine/htmengine/runtime/metric_storer.py
+++ b/htmengine/htmengine/runtime/metric_storer.py
@@ -37,7 +37,8 @@ import logging
 import os
 import time
 
-from htmengine import repository
+from htmengine import (raiseExceptionOnMissingRequiredApplicationConfigPath,
+                       repository)
 from htmengine.adapters.datasource import createCustomDatasourceAdapter
 import htmengine.exceptions
 from htmengine.htmengine_logging import getExtendedLogger
@@ -207,11 +208,11 @@ def _trimMetricCache():
       del gCustomMetrics[name]
 
 
-
+@raiseExceptionOnMissingRequiredApplicationConfigPath
 def runServer():
   # Get the current list of custom metrics
   appConfig = Config("application.conf",
-                     os.environ.get("APPLICATION_CONFIG_PATH"))
+                     os.environ["APPLICATION_CONFIG_PATH"])
 
   engine = repository.engineFactory(appConfig)
   global gCustomMetrics


### PR DESCRIPTION
…TH is not set in environment re: issue #33 

@rhyolight I think this addresses your concern.

If the required `APPLICATION_CONFIG_PATH` envvar is not set, then you will see something like the following:

```
$ python -m htmengine.runtime.metric_listener
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "[REDACTED]/htmengine/htmengine/runtime/metric_listener.py", line 49, in <module>
    from htmengine.model_swapper.model_swapper_interface import (
  File "htmengine/model_swapper/model_swapper_interface.py", line 551, in <module>
    class ModelSwapperInterface(object):
  File "htmengine/model_swapper/model_swapper_interface.py", line 570, in ModelSwapperInterface
    _RESULTS_Q_ENV_VAR = ModelSwapperConfig()._getEnvVarOverrideName(
  File "htmengine/__init__.py", line 19, in wrapper
    HTMENGINE_HOME, "README.md"))
htmengine.exceptions.ApplicationNotConfiguredError: 'Required `APPLICATION_CONFIG_PATH` not set in environment.  See [REDACTED]/htmengine/README.md for details'
```