### PR TITLE
table_name_suffix should never be blank

### DIFF
--- a/taurus/conf/application.conf
+++ b/taurus/conf/application.conf
@@ -74,4 +74,4 @@ metric_tweets_throughput_write = 3
 prefetch_count = 5
 # Dev setup should set this to ".dev" or similar, production uses ".production"
 # so make sure to avoid ".production" on any staging servers.
-table_name_suffix =
+table_name_suffix = .CHANGEME_OR_YOUR_STUFF_WILL_BREAK


### PR DESCRIPTION
Set the default dynamo table suffix so it isn't blank and is obvious that it should be changed