### PR TITLE
TAUR-1137 Revert tweet aggregation due to unacceptable processing latency

### DIFF
--- a/htmengine/htmengine/runtime/anomaly_service.py
+++ b/htmengine/htmengine/runtime/anomaly_service.py
@@ -19,6 +19,7 @@
 #
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
+
 import itertools
 import json
 import logging
@@ -31,7 +32,6 @@ import time
 import zlib
 
 from nta.utils import amqp
-from nta.utils.amqp.constants import AMQPDeliveryModes
 from nta.utils.date_time_utils import epochFromNaiveUTCDatetime
 from nta.utils.message_bus_connector import MessageBusConnector
 from nta.utils.message_bus_connector import MessageProperties

--- a/nta.utils/nta/utils/message_bus_connector.py
+++ b/nta.utils/nta/utils/message_bus_connector.py
@@ -33,12 +33,8 @@ import time
 
 import requests
 
-from nta.utils import amqp
-from nta.utils.amqp.constants import AMQPDeliveryModes, AMQPErrorCodes
-
 from nta.utils import error_handling
-
-
+from nta.utils import amqp
 
 g_log = logging.getLogger("nta.utils.message_bus_connector")
 
@@ -68,7 +64,6 @@ _RETRY_ON_AMQP_ERROR = error_handling.retry(
   retryExceptions=(
     amqp.exceptions.AmqpChannelError,
     amqp.exceptions.AmqpConnectionError,
-    amqp.exceptions.NackError,
     amqp.exceptions.UnroutableError,
     socket.gaierror,
     socket.error,

--- a/taurus/taurus/engine/runtime/dynamodb/definitions/metric_tweets_dynamodbdefinition.py
+++ b/taurus/taurus/engine/runtime/dynamodb/definitions/metric_tweets_dynamodbdefinition.py
@@ -23,7 +23,6 @@
 from collections import namedtuple
 
 from boto.dynamodb2.fields import HashKey, RangeKey, GlobalAllIndex
-from boto.dynamodb2.types import NUMBER
 
 import taurus.engine
 from taurus.engine.runtime.dynamodb.definitions.dynamodbdefinition import (
@@ -46,7 +45,7 @@ class MetricTweetsDynamoDBDefinition(DynamoDBDefinition):
   def tableCreateKwargs(self):
     return dict(
       schema=[
-        HashKey("text"),
+        HashKey("metric_name_tweet_uid"),
         RangeKey("agg_ts")
       ],
       throughput={
@@ -59,7 +58,7 @@ class MetricTweetsDynamoDBDefinition(DynamoDBDefinition):
           "taurus.metric_data-metric_name_index",
           parts=[
             HashKey("metric_name"),
-            RangeKey("sort_key", data_type=NUMBER)
+            RangeKey("agg_ts")
           ],
           throughput={
             "read": (
@@ -87,8 +86,6 @@ class MetricTweetsDynamoDBDefinition(DynamoDBDefinition):
         "text",
         "userid",
         "username",
-        "retweet_count",
-        "copy_count",
-        "sort_key"
+        "retweet_count"
       )
     )

--- a/taurus/taurus/engine/runtime/dynamodb/dynamodb_service.py
+++ b/taurus/taurus/engine/runtime/dynamodb/dynamodb_service.py
@@ -31,7 +31,6 @@ from datetime import datetime, timedelta
 from decimal import Context, Underflow, Clamped, Overflow
 import json
 import os
-import re
 import sys
 
 import boto.dynamodb2
@@ -39,12 +38,10 @@ from boto.dynamodb2.exceptions import (
     ConditionalCheckFailedException, ItemNotFound, ResourceNotFoundException,
     ValidationException, ProvisionedThroughputExceededException)
 from boto.dynamodb2.table import Table
-from boto.dynamodb2.types import NonBooleanDynamizer
 from boto.exception import JSONResponseError
 
 from nta.utils import amqp
 from nta.utils import error_handling
-from nta.utils.date_time_utils import epochFromNaiveUTCDatetime
 
 import taurus.engine
 from taurus.engine import taurus_logging
@@ -63,7 +60,6 @@ from taurus.engine import logging_support
 
 
 g_log = taurus_logging.getExtendedLogger(__name__)
-dynamizer = NonBooleanDynamizer()
 
 
 
@@ -146,7 +142,6 @@ def convertInferenceResultRowToMetricDataItem(metricId, row):
 
 
 
-
 class DynamoDBService(object):
   """ Binds a "dynamodb" queue to:
       - The model results fanout exchange defined in the
@@ -210,19 +205,6 @@ class DynamoDBService(object):
       self._gracefulCreateTable(MetricTweetsDynamoDBDefinition()))
     self._instance_data_hourly = self._gracefulCreateTable(
         InstanceDataHourlyDynamoDBDefinition())
-
-
-  @staticmethod
-  def _constructSortKey(agg_ts):
-    """ Construct an initial sort key by converting agg_ts to an epoch time,
-    and multiply it by some power of 10.  On update, the key will be
-    incremented by one atomically.  The original range queries will be
-    preserved while allowing a response with tweets sorted by popularity
-    within the time range bucket
-    """
-    ts = epochFromNaiveUTCDatetime(datetime.strptime(agg_ts.partition(".")[0],
-                                                     "%Y-%m-%dT%H:%M:%S"))
-    return int(ts * 1e5)
 
 
   @staticmethod
@@ -303,7 +285,7 @@ class DynamoDBService(object):
                       "row=%r from batchLen=%d", data, row, len(rows))
           continue
 
-        dynamodbBatchWrite.put_item(data=data._asdict(), overwrite=False)
+        dynamodbBatchWrite.put_item(data=data._asdict(), overwrite=True)
         processedKeys.add(key)
 
 
@@ -491,81 +473,22 @@ class DynamoDBService(object):
                                     batch["results"])
 
 
-  def _handleNonMetricTweetData(self, body,
-      _filter=re.compile("(?:^RT\\s+)?(.+?)(?:\\s+https?:\\/\\/\\S+\\s*)*$")):
+  def _handleNonMetricTweetData(self, body):
     """ Twitter handler. Publishes non-metric data to DynamoDB for twitter
     data pulled off of the `dynamodb` queue.
 
     :param str body: Incoming message payload as a JSON-encoded list of objects,
       with each object per
       ``taurus/metric_collectors/twitterdirect/tweet_export_schema.json``
-    :param _sre.SREPattern _filter: Compiled regex used to filter duplicate
-      tweets. The current logic removes optional "RT " from the beginning of
-      the text and optional URL from the end of the text.
-
-      For example:
-        RT @Company: Watch it again:  the story of John Doe.\nhttps://t.co/yWd0
-        RT @Company: Watch it again:  the story of John Doe.\nhttps://t.co/sdSA
-        @Company: Watch it again:  the story of John Doe.\nhttps://t.co/yWd0
-        @Company: Watch it again:  the story of John Doe.\nhttps://t.co/yWd1
-
-      All translate to:
-        @Company: Watch it again:  the story of John Doe.
     """
     payload = json.loads(body)
     g_log.info("Handling %d non-metric tweet item(s)", len(payload))
-    for item in payload:
-
-      item["metric_name_tweet_uid"] = (
-        "-".join((item["metric_name"], item["tweet_uid"])))
-
-      # Filter "RT" prefix and URL suffix
-      tweet_text = item["text"] = _filter.match(item["text"]).group(1)
-      item["copy_count"] = 0
-      item["sort_key"] = self._constructSortKey(item["agg_ts"])
-
-      data = MetricTweetsDynamoDBDefinition().Item(**item)
-
-      # First, attempt to write out metric tweet.  If a duplicate composite
-      # hash-range primary key exists (filtered text + hour), a
-      # ConditionalCheckFailedException will be raised.  In response, attempt
-      # to atomically update the "copy_count" using a conditional write
-      # operation, increasing the value by 1
-
-      @_RETRY_ON_TRANSIENT_DYNAMODB_ERROR
-      def putItemWithRetries():
-        self._metric_tweets.put_item(data._asdict(), overwrite=False)
-
-      try:
-        putItemWithRetries()
-      except ConditionalCheckFailedException:
-
-        updateKey = {"text": dynamizer.encode(tweet_text),
-                     "agg_ts": dynamizer.encode(item["agg_ts"])}
-        updateValues = {":incr": dynamizer.encode(1)}
-        updateExpression = "ADD copy_count :incr, sort_key :incr"
-        updateCondition = "attribute_exists(copy_count)"
-
-        @_RETRY_ON_TRANSIENT_DYNAMODB_ERROR
-        def updateItemWithRetries():
-          self.dynamodb.update_item(self._metric_tweets.table_name,
-                                    updateKey,
-                                    condition_expression=updateCondition,
-                                    update_expression=updateExpression,
-                                    expression_attribute_values=updateValues)
-
-        try:
-          updateItemWithRetries()
-          g_log.info("Duplicate tweet.  Atomically increased copy_count of "
-                     "original tweet.  text=%s; agg_ts=%s;",
-                     tweet_text, item["agg_ts"])
-        except Exception:
-          g_log.exception("Atomic update failed: table=%s; "
-                          "updateKey=%s; condition_expression=%s; "
-                          "expression_attribute_values=%s;",
-                          self._metric_tweets.table_name, updateKey,
-                          updateCondition, updateExpression, updateValues)
-          raise
+    with self._metric_tweets.batch_write() as dynamodbBatchWrite:
+      for item in payload:
+        item["metric_name_tweet_uid"] = (
+          "-".join((item["metric_name"], item["tweet_uid"])))
+        data = MetricTweetsDynamoDBDefinition().Item(**item)
+        dynamodbBatchWrite.put_item(data=data._asdict(), overwrite=True)
 
 
   def _purgeMetricFromDynamoDB(self, uid):
@@ -685,8 +608,9 @@ class DynamoDBService(object):
     # more simultaneous processes.
 
     amqpClient.bindQueue(exchange=self._nonMetricDataExchange,
-                         queue=result.queue,
-                         routingKey="#")  # substitute for zero or more words.
+                           queue=result.queue,
+                           routingKey="#")  # substitute for zero or more
+                                             # words.
 
 
   def run(self):

--- a/taurus/taurus/engine/runtime/dynamodb/dynamodb_service.py
+++ b/taurus/taurus/engine/runtime/dynamodb/dynamodb_service.py
@@ -519,11 +519,8 @@ class DynamoDBService(object):
       item["metric_name_tweet_uid"] = (
         "-".join((item["metric_name"], item["tweet_uid"])))
 
-      # Gracefully filter "RT" prefix and URL suffix
-      match = _filter.match(item["text"])
-      if match is not None:
-        item["text"] = match.group(1)
-      tweet_text = item["text"]
+      # Filter "RT" prefix and URL suffix
+      tweet_text = item["text"] = _filter.match(item["text"]).group(1)
       item["copy_count"] = 0
       item["sort_key"] = self._constructSortKey(item["agg_ts"])
 

--- a/taurus/tests/integration/runtime/dynamodb/dynamodb_service_test.py
+++ b/taurus/tests/integration/runtime/dynamodb/dynamodb_service_test.py
@@ -254,20 +254,12 @@ class DynamoDBServiceTest(TestCaseBase):
         body=json.dumps(twitterData)
       )
 
-
     metricTweetsTable = Table(MetricTweetsDynamoDBDefinition().tableName,
                               connection=dynamodb)
-    for _ in range(30):
-      try:
-        metricTweetItem =  metricTweetsTable.lookup(
-          twitterData[0]["text"],
-          twitterData[0]["agg_ts"]
-        )
-        break
-      except ItemNotFound:
-        # LOL eventual consistency
-        time.sleep(1)
-        continue
+    metricTweetItem =  metricTweetsTable.lookup(
+      "-".join((metricName, uid)),
+      "2015-02-19T19:43:24.870118"
+    )
     # There is no server-side cleanup for tweet data, so remove it here for
     # now to avoid accumulating test data
     self.addCleanup(metricTweetItem.delete)
@@ -279,16 +271,10 @@ class DynamoDBServiceTest(TestCaseBase):
     self.assertEqual(metricTweetItem["userid"], twitterData[0]["userid"])
     self.assertEqual(metricTweetItem["username"], twitterData[0]["username"])
     self.assertEqual(metricTweetItem["retweet_count"], twitterData[0]["retweet_count"])
-    self.assertEqual(metricTweetItem["copy_count"], 0)
 
-    sort_key = twitterData[0]["agg_ts"]
-
-    ts = (epochFromNaiveUTCDatetime(
-      datetime.datetime.strptime(twitterData[0]["agg_ts"].partition(".")[0],
-                                 "%Y-%m-%dT%H:%M:%S")) * 1e5)
     queryResult = metricTweetsTable.query_2(
       metric_name__eq=metricName,
-      sort_key__gte=ts,
+      agg_ts__eq=twitterData[0]["agg_ts"],
       index="taurus.metric_data-metric_name_index")
     queriedMetricTweetItem = next(queryResult)
 
@@ -300,56 +286,6 @@ class DynamoDBServiceTest(TestCaseBase):
     self.assertEqual(queriedMetricTweetItem["userid"], twitterData[0]["userid"])
     self.assertEqual(queriedMetricTweetItem["username"], twitterData[0]["username"])
     self.assertEqual(queriedMetricTweetItem["retweet_count"], twitterData[0]["retweet_count"])
-    self.assertEqual(queriedMetricTweetItem["copy_count"], 0)
-    self.assertEqual(queriedMetricTweetItem["sort_key"], ts)
-
-    duplicatedTwitterData = [
-      {
-        "metric_name": "copy of " + metricName,
-        "tweet_uid": "copy of " + uid,
-        "created_at": "2015-02-19T19:45:24.870109",
-        "agg_ts": "2015-02-19T19:43:24.870118", # Same agg_ts!
-        "text": "Tweet text", # Same text!
-        "userid": "20",
-        "username": "Copy of Tweet username",
-        "retweet_count": "0"
-      }
-    ]
-
-    with MessageBusConnector() as messageBus:
-      messageBus.publishExg(
-        exchange=self.config.get("non_metric_data", "exchange_name"),
-        routingKey=(
-          self.config.get("non_metric_data", "exchange_name") + ".twitter"),
-        body=json.dumps(duplicatedTwitterData)
-      )
-
-    for _ in range(30):
-      metricTweetItem =  metricTweetsTable.lookup(
-        twitterData[0]["text"],
-        twitterData[0]["agg_ts"]
-      )
-
-      if metricTweetItem["copy_count"] != 1:
-        time.sleep(1)
-        continue
-
-      # Assert same as original, except for copy_count, which should be 1
-
-      self.assertEqual(metricTweetItem["username"], twitterData[0]["username"])
-      self.assertEqual(metricTweetItem["tweet_uid"], twitterData[0]["tweet_uid"])
-      self.assertEqual(metricTweetItem["created_at"], twitterData[0]["created_at"])
-      self.assertEqual(metricTweetItem["agg_ts"], twitterData[0]["agg_ts"])
-      self.assertEqual(metricTweetItem["text"], twitterData[0]["text"])
-      self.assertEqual(metricTweetItem["userid"], twitterData[0]["userid"])
-      self.assertEqual(metricTweetItem["username"], twitterData[0]["username"])
-      self.assertEqual(metricTweetItem["retweet_count"], twitterData[0]["retweet_count"])
-      self.assertEqual(metricTweetItem["sort_key"], ts + 1)
-
-      break
-    else:
-      self.fail("copy_count of original tweet not updated within reasonable"
-                " amount of time (~30s) for duplicated tweet.")
 
     # Delete metric and ensure metric is deleted from dynamodb, too
     self._deleteMetric(metricName)

--- a/taurus/tests/unit/runtime/dynamodb/dynamodb_service_test.py
+++ b/taurus/tests/unit/runtime/dynamodb/dynamodb_service_test.py
@@ -162,7 +162,6 @@ class DynamoDBServiceTestCase(unittest.TestCase):
 
 
 
-  @unittest.skip("TODO Refactor tests for TAUR-1137")
   @patch.object(
     AnomalyService, "deserializeModelResult",
     spec_set=AnomalyService.deserializeModelResult)
@@ -340,7 +339,7 @@ class DynamoDBServiceTestCase(unittest.TestCase):
       self.assertEqual(publishInstanceMock.call_count, 0)
 
 
-  @unittest.skip("TODO Refactor tests for TAUR-1137")
+  #zzz
   @patch("taurus.engine.runtime.dynamodb.dynamodb_service.amqp",
          autospec=True)
   def testMessageHandlerRoutesTweetDataToDynamoDB(
@@ -406,7 +405,6 @@ class DynamoDBServiceTestCase(unittest.TestCase):
       overwrite=True))
 
 
-  @unittest.skip("TODO Refactor tests for TAUR-1137")
   def testPublishMetricDataWithDuplicateKeys(self, connectDynamoDB,
                                              _gracefulCreateTable):
     """ Test for elimination of rows with duplicate keys by _publishMetricData


### PR DESCRIPTION
We'll need to rethink the solution. The initial solution was having trouble clearing the backlog and keeping up with incoming data even when we bumped up the cumulative write throughput to 900 and increased dynamodb-service concurrency to 16 on a powerful EC2 instance.

CC @oxtopus @jcasner @lscheinkman 