### PR TITLE
Fix infrastructure-python-rpm generation

### DIFF
--- a/infrastructure/infrastructure/create-grok-rpm
+++ b/infrastructure/infrastructure/create-grok-rpm
@@ -29,6 +29,8 @@
 
 reporoot=$(git rev-parse --show-toplevel)
 
+# Don't quote the $@, we want it burst into separate arguments instead of
+# being treated as a single argument
 time ./create-numenta-rpm --rpm-flavor grok \
   --description "Grok installed from products rpm - ends up in /opt/numenta/products/grok" \
   --rpm-name nta-products-grok \
@@ -43,4 +45,4 @@ time ./create-numenta-rpm --rpm-flavor grok \
   --setup-py-dir htmengine \
   --setup-py-dir grok \
   --extend-pythonpath ./grok/lib/python2.7/site-packages \
-  --artifact opt "$@" 2>&1
+  --artifact opt $@ 2>&1

--- a/infrastructure/infrastructure/create-grok-saltcellar-rpm
+++ b/infrastructure/infrastructure/create-grok-saltcellar-rpm
@@ -21,6 +21,8 @@
 # ----------------------------------------------------------------------
 # Package saltcellar into an RPM for Grok
 
+# Don't quote the $@, we want it burst into separate arguments instead of
+# being treated as a single argument
 ./create-numenta-rpm --debug \
   --artifact srv \
   --description "Grok saltcellar - installs to /srv/salt" \
@@ -28,4 +30,4 @@
   --rpm-flavor saltcellar \
   --rpm-name grok-saltcellar \
   --architecture noarch \
-  --tempdir /tmp/grok-saltcellar-rpm "$@"
+  --tempdir /tmp/grok-saltcellar-rpm $@

--- a/infrastructure/infrastructure/create-infrastructure-python-rpm
+++ b/infrastructure/infrastructure/create-infrastructure-python-rpm
@@ -22,6 +22,8 @@
 
 # Create a numenta-infrastructure-python rpm
 
+# Don't quote the $@, we want it burst into separate arguments instead of
+# being treated as a single argument
 ./create-numenta-rpm \
   --artifact opt \
   --description "Numenta infrastructure-common python utility modules" \
@@ -29,4 +31,4 @@
   --rpm-flavor infrastructure \
   --rpm-name numenta-infrastructure-python \
   --architecture noarch \
-  --tempdir /tmp/grok-saltcellar-rpm "$@"
+  --tempdir /tmp/grok-saltcellar-rpm $@

--- a/infrastructure/infrastructure/create-numenta-rpm
+++ b/infrastructure/infrastructure/create-numenta-rpm
@@ -625,7 +625,12 @@ def constructInfrastructureFakeroot(fakeroot):
   infraPath = "%s/infrastructure" % productsPath
   purgeDirectory(path=infraPath,
                  whitelist=["__init__.py",
-                            "utilities"],
+                            "DEPENDENCIES.md",
+                            "infrastructure",
+                            "LICENSE",
+                            "README.md",
+                            "requirements.txt",
+                            "setup.py"],
                  logger=g_logger)
 
   return (iteration, fakerootSHA)

--- a/infrastructure/infrastructure/infrastructure-python-postinstall
+++ b/infrastructure/infrastructure/infrastructure-python-postinstall
@@ -31,5 +31,6 @@ export PYTHONPATH="${ANACONDA_D}/lib/python2.7/site-packages"
 
 cd /opt/numenta/products/infrastructure
 
-./setup.py install --install-dir="${ANACONDA_D}/lib/python2.7/site-packages" \
+python ./setup.py install \
+  --install-dir="${ANACONDA_D}/lib/python2.7/site-packages" \
   --script-dir="${ANACONDA_D}/bin"

--- a/infrastructure/infrastructure/infrastructure-python-postinstall
+++ b/infrastructure/infrastructure/infrastructure-python-postinstall
@@ -18,16 +18,18 @@
 # along with this program.  If not, see http://www.gnu.org/licenses.
 #
 # http://numenta.org/licenses/
+ANACONDA_D="/opt/numenta/anaconda"
 
 # Set a proper PATH
 # Start prepending directories
 PATH="/usr/local/bin:${PATH}"
 PATH="/usr/local/sbin:${PATH}"
-export PATH="/opt/numenta/anaconda/bin:${PATH}"
+export PATH="${ANACONDA_D}/bin:${PATH}"
 
 # Use anaconda's PYTHONPATH
-export PYTHONPATH="/opt/numenta/anaconda/lib/python2.7/site-packages"
+export PYTHONPATH="${ANACONDA_D}/lib/python2.7/site-packages"
 
 cd /opt/numenta/products/infrastructure
 
-./setup.py install
+./setup.py install --install-dir="${ANACONDA_D}/lib/python2.7/site-packages" \
+  --script-dir="${ANACONDA_D}/bin"

--- a/infrastructure/infrastructure/infrastructure-python-postinstall
+++ b/infrastructure/infrastructure/infrastructure-python-postinstall
@@ -18,18 +18,16 @@
 # along with this program.  If not, see http://www.gnu.org/licenses.
 #
 # http://numenta.org/licenses/
-# ----------------------------------------------------------------------
 
-# Create a numenta-infrastructure-python rpm
+# Set a proper PATH
+# Start prepending directories
+PATH="/usr/local/bin:${PATH}"
+PATH="/usr/local/sbin:${PATH}"
+export PATH="/opt/numenta/anaconda/bin:${PATH}"
 
-# Don't quote the $@, we want it burst into separate arguments instead of
-# being treated as a single argument
-./create-numenta-rpm \
-  --artifact opt \
-  --description "Numenta infrastructure-common python utility modules" \
-  --log-level warning \
-  --rpm-flavor infrastructure \
-  --rpm-name numenta-infrastructure-python \
-  --architecture noarch \
-  --postinstall-script infrastructure-python-postinstall \
-  --tempdir /tmp/grok-saltcellar-rpm $@
+# Use anaconda's PYTHONPATH
+export PYTHONPATH="/opt/numenta/anaconda/lib/python2.7/site-packages"
+
+cd /opt/numenta/products/infrastructure
+
+./setup.py install


### PR DESCRIPTION
* Paths were changed when the infrastructure module was refactored to become installable with `setup.py`, update them in `create-numenta-rpm`
* Update $@ treatment in create-*-rpm scripts
* We now use `setup.py install` in the postinstall to properly add the infrastructure module to anaconda's site-python.

This now generates an rpm with contents
```
rpm -qlp numenta-infrastructure-python-1.7.1-223.noarch.rpm
/opt/numenta/products/infrastructure/DEPENDENCIES.md
/opt/numenta/products/infrastructure/LICENSE
/opt/numenta/products/infrastructure/README.md
/opt/numenta/products/infrastructure/infrastructure/__init__.py
/opt/numenta/products/infrastructure/infrastructure/create-grok-rpm
/opt/numenta/products/infrastructure/infrastructure/create-grok-saltcellar-rpm
/opt/numenta/products/infrastructure/infrastructure/create-infrastructure-python-rpm
/opt/numenta/products/infrastructure/infrastructure/create-numenta-rpm
/opt/numenta/products/infrastructure/infrastructure/utilities/__init__.py
/opt/numenta/products/infrastructure/infrastructure/utilities/cli.py
/opt/numenta/products/infrastructure/infrastructure/utilities/ec2.py
/opt/numenta/products/infrastructure/infrastructure/utilities/env.py
/opt/numenta/products/infrastructure/infrastructure/utilities/exceptions.py
/opt/numenta/products/infrastructure/infrastructure/utilities/git.py
/opt/numenta/products/infrastructure/infrastructure/utilities/grok_server.py
/opt/numenta/products/infrastructure/infrastructure/utilities/infrastructure-rpm-pipeline/conf/config.yaml
/opt/numenta/products/infrastructure/infrastructure/utilities/infrastructure-rpm-pipeline/run_pipeline
/opt/numenta/products/infrastructure/infrastructure/utilities/janitor_pipeline/janitor_ec2.py
/opt/numenta/products/infrastructure/infrastructure/utilities/jenkins.py
/opt/numenta/products/infrastructure/infrastructure/utilities/logger.py
/opt/numenta/products/infrastructure/infrastructure/utilities/nupic/__init__.py
/opt/numenta/products/infrastructure/infrastructure/utilities/nupic/build_commands.py
/opt/numenta/products/infrastructure/infrastructure/utilities/nupic/run_pipeline
/opt/numenta/products/infrastructure/infrastructure/utilities/path.py
/opt/numenta/products/infrastructure/infrastructure/utilities/rpm.py
/opt/numenta/products/infrastructure/infrastructure/utilities/s3.py
/opt/numenta/products/infrastructure/infrastructure/utilities/saucelabs.py
/opt/numenta/products/infrastructure/infrastructure/utilities/ssh.py
/opt/numenta/products/infrastructure/infrastructure/utilities/strip_ansi
/opt/numenta/products/infrastructure/requirements.txt
/opt/numenta/products/infrastructure/setup.py
[ec2-user@rpmbuild infrastructure]$
```