### PR TITLE
Add compiler dependency onto anaconda

### DIFF
--- a/infrastructure/saltcellar/numenta-python/init.sls
+++ b/infrastructure/saltcellar/numenta-python/init.sls
@@ -31,6 +31,8 @@ anaconda-python:
     - installed
     - pkgs:
       - gs-anaconda
+    - require:
+      - pkg: compiler-toolchain
     - watch_in:
       - cmd: enforce-anaconda-permissions
 


### PR DESCRIPTION
Some of the packages we're installing in python by default require gcc to build.