### PR TITLE
TAUR-1217 Fix epel repo installation

### DIFF
--- a/infrastructure/ami-tools/ami-configurations/grok-pipeline.json
+++ b/infrastructure/ami-tools/ami-configurations/grok-pipeline.json
@@ -59,11 +59,6 @@
       "type": "file"
     },
     {
-      "destination": "/tmp/epel.repo",
-      "source": "repos/epel.repo",
-      "type": "file"
-    },
-    {
       "inline": [
         "echo 'Sleeping for 30s, waiting for system to settle down.'",
         "sleep 30",
@@ -72,6 +67,10 @@
         "mkdir -p /srv/salt"
       ],
       "type": "shell"
+    },
+    {
+      "type": "shell",
+      "script": "packer-scripts/install-epel-repo-6.5"
     },
     {
       "type": "shell",

--- a/infrastructure/ami-tools/packer-scripts/configure-grok-pipeline-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-grok-pipeline-ami
@@ -73,8 +73,7 @@ install-prerequisites-and-update-repos() {
   yum clean all
 
   echo "Ensure Numenta S3 repos are current..."
-  for repo in epel.repo \
-              grok-development.repo \
+  for repo in grok-development.repo \
               grok-release-candidates.repo \
               grok-releases.repo \
               nta-carbonite.repo \


### PR DESCRIPTION
The epel repository is available as an RPM. We've been installing it by just copying a file into `/etc/yum.repos.d`, but that is a bad idea since that file isn't getting updated and the epel-release RPM is.

The grok-pipeline now uses the `install-epel-repo-6.5` packer script to remove the old stale repo file, update ca-certificates (if we don't get current on ca-certificates, the epel repo will cause yum to fail SSL checks), then install the epel repo via the rpm.

This change was already applied to the grok-plumbing packer configuration when I initially implemented it for our infrastructure AMIs in [#72](https://github.com/numenta/numenta-apps/pull/72) somehow we missed adding it to the grok-pipeline packer configuration then.