### PR TITLE
Fix issues with mysql formula

### DIFF
--- a/infrastructure/saltcellar/mysql/client.sls
+++ b/infrastructure/saltcellar/mysql/client.sls
@@ -27,7 +27,8 @@ include:
 
 {% if grains['os_family'] == 'RedHat' %}
 
-mysql-community-client:
-  pkg.latest
+install-mysql-client:
+  pkg.latest:
+    - name: mysql-community-client
 
 {% endif %}

--- a/infrastructure/saltcellar/mysql/server.sls
+++ b/infrastructure/saltcellar/mysql/server.sls
@@ -23,6 +23,7 @@
 # Installs the MySQL community repository, then installs MySQL 5.6.23
 
 include:
+  - mysql.client
   - mysql.repositories
 
 {% if grains['os_family'] == 'RedHat' %}
@@ -38,15 +39,11 @@ include:
     - require:
       - pkg: mysql-community-server
 
-mysql-community-server:
-  pkg.installed:
-    - version: 5.6.23-2.el6
-    -require:
-      - pkg: mysql-community-client
-
-mysql-community-client:
-  pkg.installed:
-    - version: 5.6.23-2.el6
+install-mysqld:
+  pkg.latest:
+    - name: mysql-community-server
+    - require:
+      - pkg: install-mysql-client
 
 mysqld.service:
   service.running:


### PR DESCRIPTION
* Make the state names generic so we can change where we get the RPMs from more easily. This should make the CentOS 7 upgrade less painful.
* Fix parse error in mysql.server.sls