### PR TITLE
TAUR-1272 Update rabbitmq dependency information

### DIFF
--- a/infrastructure/saltcellar/numenta-python/init.sls
+++ b/infrastructure/saltcellar/numenta-python/init.sls
@@ -49,7 +49,7 @@ anaconda-paver:
 
 anaconda-pip:
   pip.installed:
-    - name: pip == 7.0.3
+    - name: pip == 7.1.0
     - bin_env: /opt/numenta/anaconda/bin/pip
     - watch_in:
       - cmd: enforce-anaconda-permissions

--- a/infrastructure/saltcellar/rabbitmq/init.sls
+++ b/infrastructure/saltcellar/rabbitmq/init.sls
@@ -53,9 +53,9 @@ enable-rabbitmq-management:
       - service: rabbitmq-server
     - unless: grep rabbitmq_management /etc/rabbitmq/enabled_plugins
     - watch_in:
-      - cmd: kick-rabbit-service
+      - cmd: restart-rabbit-service
 
-kick-rabbit-service:
+restart-rabbit-service:
   cmd.wait:
     - name: service rabbitmq-server restart
     - require:

--- a/infrastructure/saltcellar/rabbitmq/init.sls
+++ b/infrastructure/saltcellar/rabbitmq/init.sls
@@ -43,12 +43,21 @@ rabbitmq-server:
   service.running:
     - enable: true
     - require:
+      - file: /etc/rabbitmq
       - pkg: rabbitmq-server
 
 enable-rabbitmq-management:
   cmd.run:
     - name: /usr/lib/rabbitmq/bin/rabbitmq-plugins enable rabbitmq_management
     - require:
+      - service: rabbitmq-server
+    - unless: grep rabbitmq_management /etc/rabbitmq/enabled_plugins
+    - watch_in:
+      - cmd: kick-rabbit-service
+
+kick-rabbit-service:
+  cmd.wait:
+    - name: service rabbitmq-server restart
+    - require:
       - pkg: rabbitmq-server
       - service: rabbitmq-server
-


### PR DESCRIPTION
* Stop attempting to install rabbitmq_management if it is already installed.
* Ensure that rabbitmq-server is restarted after installing the management plugin