### PR TITLE
Stop zsh and bash from complaining about no ssh-agent

### DIFF
--- a/infrastructure/saltcellar/dotfiles/files/bash_profile_skeleton.sh
+++ b/infrastructure/saltcellar/dotfiles/files/bash_profile_skeleton.sh
@@ -114,8 +114,9 @@ if [ -f ~/.sh_aliases ]; then
   source ~/.sh_aliases
 fi
 
-df -h
-
-echo
-echo "SSH keys:"
-ssh-add -l
+SSHkeylist=$(ssh-add -l 2>&1)
+if [[ $? == "0" ]]; then
+  echo
+  echo "SSH keys:"
+  echo "${SSHkeylist}"
+fi

--- a/infrastructure/saltcellar/dotfiles/files/zshrc_skeleton.zsh
+++ b/infrastructure/saltcellar/dotfiles/files/zshrc_skeleton.zsh
@@ -158,8 +158,9 @@ unset REMOVE_CP_ALIAS
 unset REMOVE_MV_ALIAS
 unset REMOVE_RM_ALIAS
 
-df -h
-
-echo
-echo "SSH keys:"
-ssh-add -l
+SSHkeylist=$(ssh-add -l 2>&1)
+if [[ $? == "0" ]]; then
+  echo
+  echo "SSH keys:"
+  echo "${SSHkeylist}"
+fi


### PR DESCRIPTION
Make login less spammy. We now only show ssh keys when they're actually present.

This also squelches console spam when the grok init script drops privileges to ec2-user during service startup.

@shantanoo @jcasner please CR.