### PR TITLE
TAUR-834 Don't retrieve EC2 metadata if running on Mac OS.

### DIFF
--- a/grok/grok/app/aws/instance_utils.py
+++ b/grok/grok/app/aws/instance_utils.py
@@ -18,6 +18,8 @@
 #
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
+import sys
+
 import requests
 
 
@@ -44,7 +46,12 @@ def getInstanceData():
       "availabilityZone" : "us-east-1d"
     }
 
+  :returns: dict of EC2 instance data; None if not available
+
   """
+  if sys.platform.startswith("darwin"):
+    return None
+
   url = "http://169.254.169.254/latest/dynamic/instance-identity/document"
 
   try:


### PR DESCRIPTION
Don't retrieve EC2 metadata if running on Mac OS. This removes the significant delay that was occurring when loading the Grok GUI on Mac OS X as well as anything else that used grok/app/aws/instance_utils.py