### PR TITLE
TAUR-834 Extend _AutostackDatasourceAdapter.getInstanceNameForModelSpec to support import-model-spec

### DIFF
--- a/grok/grok/app/webservices/models_api.py
+++ b/grok/grok/app/webservices/models_api.py
@@ -398,8 +398,9 @@ class ModelHandler(AuthenticatedBaseHandler):
           if modelSpec["datasource"] == "custom":
             checkQuotaForCustomMetricAndRaise(conn)
           else:
-            instanceName = adapter.getInstanceNameForModelSpec(modelSpec)
-            checkQuotaForInstanceAndRaise(conn, instanceName)
+            checkQuotaForInstanceAndRaise(
+              conn,
+              adapter.getInstanceNameForModelSpec(modelSpec))
 
           try:
             if importing:


### PR DESCRIPTION
If import-model-spec is passed to _AutostackDatasourceAdapter.getInstanceNameForModelSpec, attempt to map the autostack name/region to autostack id. If autstack doesn't exist, return None as permitted by DatasourceAdapterIface.getInstanceNameForModelSpec