### PR TITLE
TAUR-1284 Increase timeout in checkModelDeleted() from 25 to 60

### DIFF
--- a/grok/grok/test_utils/app/test_case_base.py
+++ b/grok/grok/test_utils/app/test_case_base.py
@@ -193,7 +193,7 @@ class TestCaseBase(unittest.TestCase):
     self.assertIn(uid, uidSet)
 
 
-  @retry(duration=25)
+  @retry(duration=60)
   def checkModelDeleted(self, uid):
     """Check that the model has been deleted"""
 


### PR DESCRIPTION
@jcasner This causes the test to pass in the slower instance type. re: https://jira.numenta.com/browse/TAUR-1284