### PR TITLE
TAUR-873 Fixed incorrect SP configuration property names

### DIFF
--- a/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_0_params.json
+++ b/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_0_params.json
@@ -52,7 +52,7 @@
         "synPermConnected": 0.10000000000000001,
         "numActiveColumnsPerInhArea": 40,
         "seed": 1956,
-        "columnDimensions": 0.8,
+        "potentialPct": 0.8,
         "globalInhibition": 1,
         "maxBoost": 1.0
       },

--- a/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_1_params.json
+++ b/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_1_params.json
@@ -52,7 +52,7 @@
         "synPermConnected": 0.10000000000000001,
         "numActiveColumnsPerInhArea": 40,
         "seed": 1956,
-        "columnDimensions": 0.8,
+        "potentialPct": 0.8,
         "globalInhibition": 1,
         "maxBoost": 1.0
       },

--- a/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_2_params.json
+++ b/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_2_params.json
@@ -52,7 +52,7 @@
         "synPermInactiveDec": 0.0005,
         "numActiveColumnsPerInhArea": 40,
         "seed": 1956,
-        "columnDimensions": 0.8,
+        "potentialPct": 0.8,
         "globalInhibition": 1,
         "maxBoost": 1.0
       },

--- a/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_3_params.json
+++ b/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_3_params.json
@@ -52,7 +52,7 @@
         "synPermConnected": 0.10000000000000001,
         "numActiveColumnsPerInhArea": 40,
         "seed": 1956,
-        "columnDimensions": 0.8,
+        "potentialPct": 0.8,
         "globalInhibition": 1,
         "maxBoost": 1.0
       },

--- a/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_4_params.json
+++ b/htmengine/htmengine/algorithms/modelSelection/anomaly_params_random_encoder/5AnomalyEnergyWithTimeCentroids_4_params.json
@@ -52,7 +52,7 @@
         "synPermConnected": 0.10000000000000001,
         "numActiveColumnsPerInhArea": 40,
         "seed": 1956,
-        "columnDimensions": 0.8,
+        "potentialPct": 0.8,
         "globalInhibition": 1,
         "maxBoost": 1.0
       },

--- a/htmengine/htmengine/algorithms/modelSelection/scalarMetricWithTimeOfDayAnomalyParams/5AnomalyEnergyWithTimeCentroids_0_params.json
+++ b/htmengine/htmengine/algorithms/modelSelection/scalarMetricWithTimeOfDayAnomalyParams/5AnomalyEnergyWithTimeCentroids_0_params.json
@@ -54,7 +54,7 @@
         "synPermConnected": 0.10000000000000001,
         "numActiveColumnsPerInhArea": 40,
         "seed": 1956,
-        "columnDimensions": 0.8,
+        "potentialPct": 0.8,
         "globalInhibition": 1,
         "maxFiringBoost": 1.0,
         "maxSynPermBoost": 1.0

--- a/htmengine/htmengine/algorithms/modelSelection/scalarMetricWithTimeOfDayAnomalyParams/5AnomalyEnergyWithTimeCentroids_1_params.json
+++ b/htmengine/htmengine/algorithms/modelSelection/scalarMetricWithTimeOfDayAnomalyParams/5AnomalyEnergyWithTimeCentroids_1_params.json
@@ -55,7 +55,7 @@
         "synPermConnected": 0.10000000000000001,
         "numActiveColumnsPerInhArea": 40,
         "seed": 1956,
-        "columnDimensions": 0.8,
+        "potentialPct": 0.8,
         "globalInhibition": 1,
         "maxBoost": 1.0
       },

--- a/htmengine/htmengine/algorithms/modelSelection/scalarMetricWithTimeOfDayAnomalyParams/5AnomalyEnergyWithTimeCentroids_2_params.json
+++ b/htmengine/htmengine/algorithms/modelSelection/scalarMetricWithTimeOfDayAnomalyParams/5AnomalyEnergyWithTimeCentroids_2_params.json
@@ -54,7 +54,7 @@
         "synPermInactiveDec": 0.0005,
         "numActiveColumnsPerInhArea": 40,
         "seed": 1956,
-        "columnDimensions": 0.8,
+        "potentialPct": 0.8,
         "globalInhibition": 1,
         "maxFiringBoost": 1.0,
         "maxSynPermBoost": 1.0

--- a/htmengine/htmengine/algorithms/modelSelection/scalarMetricWithTimeOfDayAnomalyParams/5AnomalyEnergyWithTimeCentroids_3_params.json
+++ b/htmengine/htmengine/algorithms/modelSelection/scalarMetricWithTimeOfDayAnomalyParams/5AnomalyEnergyWithTimeCentroids_3_params.json
@@ -54,7 +54,7 @@
         "synPermConnected": 0.10000000000000001,
         "numActiveColumnsPerInhArea": 40,
         "seed": 1956,
-        "columnDimensions": 0.8,
+        "potentialPct": 0.8,
         "globalInhibition": 1,
         "maxFiringBoost": 1.0,
         "maxSynPermBoost": 1.0


### PR DESCRIPTION
This issue was introduced in https://github.com/GrokSolutions/products/pull/768. The fix renames "columnDimensions" -> "potentialPct" in htmengine/algorithms/modelSelection parameter files.

NOTE that this change does not fully address TAUR-873. There are also issues in nupic that separately contribute to the failure.