### PR TITLE
Declare model results exchange as the more flexible topic exchange

### DIFF
--- a/grok/grok/app/runtime/notification_service.py
+++ b/grok/grok/app/runtime/notification_service.py
@@ -153,7 +153,7 @@ class NotificationService(object):
   """ Notification Service to monitor model inference results and trigger
       notifications where appropriate.
 
-      Binds a "notifications" queue to the model results fanout exchange
+      Binds a "notifications" queue to the model results topic exchange
       defined in the ``results_exchange_name`` configuration directive of the
       ``metric_streamer`` configuration section.
   """
@@ -382,13 +382,13 @@ class NotificationService(object):
         # make sure the queue and exchanges exists and the queue is bound
         amqpClient.declareExchange(self._modelResultsExchange,
                                    durable=True,
-                                   exchangeType="fanout")
+                                   exchangeType="topic")
 
         result = amqpClient.declareQueue("notifications", durable=True)
 
         amqpClient.bindQueue(queue=result.queue,
                              exchange=self._modelResultsExchange,
-                             routingKey="")
+                             routingKey="#")
 
         # Start consuming messages
         consumer = amqpClient.createConsumer(result.queue)

--- a/grok/tests/py/integration/app/result_quality_test.py
+++ b/grok/tests/py/integration/app/result_quality_test.py
@@ -126,7 +126,7 @@ class ResultQualityTests(test_case_base.TestCaseBase):
       amqpClient.bindQueue(
         queue=self.resultsQueueName,
         exchange=config.get("metric_streamer", "results_exchange_name"),
-        routingKey="")
+        routingKey="#")
 
 
   def testIIOData(self):
@@ -291,11 +291,7 @@ class ResultQualityTests(test_case_base.TestCaseBase):
 
   def _reapAnomalyServiceResults(self, metricId, numRowsExpected):
     """ Retrieve likelihood results from our AMQP message queue that is bound to
-    Anomaly Service's results fanout exchange
-
-    NOTE that Anomaly Service fans out all results for all models via "fanout"
-    exchange, so our queue might contain results from additional models, which
-    we filter out.
+    Anomaly Service's results topic exchange
 
     :param metricId: unique id of our metric/model
     :param numRowsExpected: number of result rows expected by caller

--- a/taurus/taurus/engine/runtime/dynamodb/dynamodb_service.py
+++ b/taurus/taurus/engine/runtime/dynamodb/dynamodb_service.py
@@ -23,7 +23,7 @@
 """ DynamoDB Service
 
 Subscribes to a dynamodb queue bound to model results and non-metric data
-fanout exchanges and forwards data to dynamodb for consumption by mobile
+topic exchanges and forwards data to dynamodb for consumption by mobile
 client.
 """
 
@@ -144,7 +144,7 @@ def convertInferenceResultRowToMetricDataItem(metricId, row):
 
 class DynamoDBService(object):
   """ Binds a "dynamodb" queue to:
-      - The model results fanout exchange defined in the
+      - The model results topic exchange defined in the
         ``results_exchange_name`` configuration directive of the
         ``metric_streamer`` configuration section.
       - Non-metric data topic exchange defined in the ``exchange_name``
@@ -577,7 +577,7 @@ class DynamoDBService(object):
     """ Declares model results and non-metric data exchanges
     """
     amqpClient.declareExchange(exchange=self._modelResultsExchange,
-                               exchangeType="fanout",
+                               exchangeType="topic",
                                durable=True)
     amqpClient.declareExchange(exchange=self._nonMetricDataExchange,
                                exchangeType="topic",
@@ -591,7 +591,7 @@ class DynamoDBService(object):
     result = amqpClient.declareQueue(self._queueName, durable=True)
 
     amqpClient.bindQueue(exchange=self._modelResultsExchange,
-                         queue=result.queue, routingKey="")
+                         queue=result.queue, routingKey="#")
 
     # Note: We're using a topic exchange with a permissive wildcard routing
     # key.  This routes all messages from the non-metric data exchange into

--- a/taurus/tests/unit/runtime/dynamodb/dynamodb_service_test.py
+++ b/taurus/tests/unit/runtime/dynamodb/dynamodb_service_test.py
@@ -138,7 +138,7 @@ class DynamoDBServiceTestCase(unittest.TestCase):
 
     amqpClientMock.declareExchange.assert_any_call(
       durable=True,
-      exchangeType="fanout",
+      exchangeType="topic",
       exchange=taurus.engine.config.get("metric_streamer", "results_exchange_name"))
 
     amqpClientMock.declareExchange.assert_any_call(
@@ -151,7 +151,7 @@ class DynamoDBServiceTestCase(unittest.TestCase):
     amqpClientMock.bindQueue.assert_any_call(
       queue=amqpClientMock.declareQueue.return_value.queue,
       exchange=taurus.engine.config.get("metric_streamer", "results_exchange_name"),
-      routingKey="")
+      routingKey="#")
 
     amqpClientMock.bindQueue.assert_any_call(
       exchange=taurus.engine.config.get("non_metric_data", "exchange_name"),


### PR DESCRIPTION
This also adds a new CLI option "--migrate" to htmengine.runtime.anomaly_service so that this, and other future migrations may be applied by calling `python -m htmengine.runtime.anomaly_service --migrate`.

Not tied to any specific issue, but this is in response to working on https://github.com/nupic-community/skeleton-htmengine-app in which I wanted to demonstrate how to synchronously receive results for a specific model, which is not possible with a fanout exchange.  This change is also anticipatory for potential future requirements in a distributed systems setting.

cc @vitaly-krugl 