### PR TITLE
TAUR-1271 TAUR-851 Update ami bake

### DIFF
--- a/infrastructure/ami-tools/packer-scripts/cleanup-grok-pipeline-ami
+++ b/infrastructure/ami-tools/packer-scripts/cleanup-grok-pipeline-ami
@@ -37,7 +37,7 @@ CONF_D="${GROK_HOME}/conf"
 UPDATERS_D="${GROK_HOME}/bin/updaters"
 RECEIPTS_D=/etc/grok/updater_statuses
 
-complain() {
+logline() {
   echo "$@"
   logger -t ami-bake "$@"
 }
@@ -97,7 +97,7 @@ cleanup_grok_conf_files(){
 }
 
 confirm_authorized_keys_removal(){
-  complain "Confirming authorized_keys removal"
+  logline "Confirming authorized_keys removal"
   find /home -name authorized_keys -print
   find /home -iname '*.pub' -print
   find /root -name authorized_keys -print
@@ -106,24 +106,24 @@ confirm_authorized_keys_removal(){
 
 cleanup_grok_logfiles() {
   echo "**********"
-  complain "Cleaning rabbit logs"
+  logline "Cleaning rabbit logs"
   rm -frv "${NUMENTA_D}"/logs/rabbitmq/*
 
   echo "**********"
-  complain "Cleaning updater logs..."
+  logline "Cleaning updater logs..."
   rm -fv "${NUMENTA_D}"/updater/logs/*
 
   echo "**********"
-  complain "Removing firstboot tag files"
+  logline "Removing firstboot tag files"
   rm -fv /etc/grok/firstboot.run /etc/grok/firstboot-root.run
 
   echo "**********"
-  complain "Clearing grok uuid"
+  logline "Clearing grok uuid"
   rm -vf "${CONF_D}/.grok_id"
 
   # Fix MER-2120
   if [ -d "${UPDATERS_D}" ]; then
-    complain "Marking all existing updaters as having been run"
+    logline "Marking all existing updaters as having been run"
     for old_updater in "${UPDATERS_D}"/*
     do
       touch "${RECEIPTS_D}"/$(basename ${old_updater})

--- a/infrastructure/ami-tools/packer-scripts/cleanup-image
+++ b/infrastructure/ami-tools/packer-scripts/cleanup-image
@@ -23,7 +23,7 @@
 # Keep this as generic as possible. Grok specific cleanups should go into
 # a separate cleanup-grok script, Taurus to cleanup-taurus, etc.
 
-complain() {
+logline() {
   echo "$@"
   logger -t ami-bake "$@"
 }
@@ -85,7 +85,7 @@ echo "CentOS version: $(cat /etc/centos-release)"
 
 echo
 echo "**********"
-complain "Zapping logfiles..."
+logline "Zapping logfiles..."
 logger -t image-cleanup "Zapping logfiles..."
 for logf in /var/log/cron \
             /var/log/dracut.log \
@@ -94,7 +94,7 @@ for logf in /var/log/cron \
             /var/log/secure \
             /var/log/yum.log
 do
-  complain "Resetting ${logf}"
+  logline "Resetting ${logf}"
   cat /dev/null > "${logf}"
 done
 

--- a/infrastructure/ami-tools/packer-scripts/cleanup-image
+++ b/infrastructure/ami-tools/packer-scripts/cleanup-image
@@ -31,14 +31,6 @@ complain() {
 echo
 echo "Cleaning instance for AMI bake"
 
-echo
-echo "If we don't purge authorized_keys, we won't be able to log into instances"
-echo "started from the AMI."
-echo
-echo "Purging authorized_keys files..."
-rm -fv /root/.ssh/authorized_keys /home/ec2-user/.ssh/authorized_keys
-find /home -name authorized_keys -exec rm -fv '{}' ';'
-
 if [ ! -z "${DEBUG}" ]; then
   echo "**********"
   echo "Yum repositories:"
@@ -78,16 +70,6 @@ rm -fr /tmp/*
 
 echo
 echo "**********"
-complain "Zapping logfiles..."
-logger -t image-cleanup "Zapping logfiles..."
-for logf in /var/log/messages /var/log/secure /var/log/cron /var/log/dracut.log /var/log/maillog /var/log/yum.log
-do
-  complain "Resetting ${logf}"
-  cat /dev/null > "${logf}"
-done
-
-echo
-echo "**********"
 echo "Purging salt minion key data..."
 rm -fr /etc/salt/pki/minion/*
 
@@ -100,3 +82,20 @@ df -h /
 echo
 
 echo "CentOS version: $(cat /etc/centos-release)"
+
+echo
+echo "**********"
+complain "Zapping logfiles..."
+logger -t image-cleanup "Zapping logfiles..."
+for logf in /var/log/cron \
+            /var/log/dracut.log \
+            /var/log/maillog \
+            /var/log/messages \
+            /var/log/secure \
+            /var/log/yum.log
+do
+  complain "Resetting ${logf}"
+  cat /dev/null > "${logf}"
+done
+
+find / -name '*.rpmnew' -print

--- a/infrastructure/ami-tools/packer-scripts/cleanup-infrastructure-ami
+++ b/infrastructure/ami-tools/packer-scripts/cleanup-infrastructure-ami
@@ -24,23 +24,23 @@
 
 saltConfigured=/etc/numenta/salt_configured
 
-complain() {
+logline() {
   echo "$@"
   logger -t ami-bake "$@"
 }
 
 echo
-echo "Infrastructure AMI cleanups"
+logline "Infrastructure AMI cleanups"
 
 service salt-minion stop
 
-echo
-echo "**********"
-echo "Purging salt minion id..."
+logline
+logline "**********"
+logline "Purging salt minion id..."
 rm -fr /etc/salt/minion_id
 
-echo "Clearing salt configuration flag"
+logline "Clearing salt configuration flag"
 rm -f "${saltConfigured}"
 
-echo "Purging salt-solo formulas"
+logline "Purging salt-solo formulas"
 rm -fr /srv/salt/*

--- a/infrastructure/ami-tools/packer-scripts/configure-infrastructure-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-infrastructure-ami
@@ -27,11 +27,6 @@ echo "Marking instance as being an Infrastructure AMI build..."
 AMIBUILD_LOCK=/tmp/baking-ami
 touch "${AMIBUILD_LOCK}"
 
-complain() {
-  echo "$@"
-  logger -t ami-bake "$@"
-}
-
 echo "Installing Numenta repositories..."
 mv /tmp/nta-carbonite.repo /etc/yum.repos.d
 mv /tmp/nta-thirdparty.repo /etc/yum.repos.d

--- a/infrastructure/ami-tools/packer-scripts/configure-infrastructure-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-infrastructure-ami
@@ -37,6 +37,16 @@ mv /tmp/nta-carbonite.repo /etc/yum.repos.d
 mv /tmp/nta-thirdparty.repo /etc/yum.repos.d
 mv /tmp/secretsauce.repo /etc/yum.repos.d
 
+echo "Installing mysql community repository..."
+yum install -y http://repo.mysql.com/mysql-community-release-el6-5.noarch.rpm
+
+echo "Installing mysql-python..."
+yum install -y mysql-community-devel python-devel
+
+# Use /usr/bin/pip so this is visible to salt or instances won't be able to
+# create MySQL users or grant privileges to them.
+/usr/bin/pip install mysql-python
+
 echo "Cleaning yum..."
 yum clean all
 
@@ -55,38 +65,21 @@ cat /etc/salt/minion_id
 echo "Stopping Salt..."
 service salt-minion stop
 
-echo "Setting search list in /etc/resolv.conf to numenta.com"
-sed 's/^search .*/search numenta.com/g' /etc/resolv.conf -i''
-cat /etc/resolv.conf
-host salt.numenta.com
+# echo "Setting search list in /etc/resolv.conf to numenta.com"
+# # sed 's/^search .*/search numenta.com/g' /etc/resolv.conf -i''
+# cat /etc/resolv.conf
+# host salt.numenta.com
 
-echo "Configuring Salt minion_id"
-echo
-echo "Setting Salt minion_id: $(cat /tmp/infrastructure_minion_id)"
-cat /tmp/infrastructure_minion_id > /etc/salt/minion_id
+echo "Salt minion_id: $(cat /etc/salt/minion_id)"
 
-echo "Setting salt master name"
-sed 's/^#master:/master: salt.numenta.com/g' /etc/salt/minion -i''
-grep ^master: /etc/salt/minion
-retcode="$?"
-if [ "${retcode}" != "0" ]; then
-  echo "Failed to set salt master name"
-  echo "Check for changes to default /etc/salt/minion"
-  exit "${retcode}"
-fi
+# echo "Purging salt minion key data..."
+# rm -fr /etc/salt/pki/minion/*
 
-echo "Purging salt minion key data..."
-rm -fr /etc/salt/pki/minion/*
+# echo "Restarting salt minion..."
+# service salt-minion restart
 
-echo "Restarting salt minion..."
-service salt-minion restart
-
-echo "Wait for master to sign key..."
-sleep 10
-
-# echo
-# echo "Test salt config"
-# salt-call state.highstate test=True
+# echo "Wait for master to sign key..."
+# sleep 10
 
 echo
 echo "Running Salt..."

--- a/infrastructure/ami-tools/packer-scripts/configure-infrastructure-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-infrastructure-ami
@@ -60,21 +60,7 @@ cat /etc/salt/minion_id
 echo "Stopping Salt..."
 service salt-minion stop
 
-# echo "Setting search list in /etc/resolv.conf to numenta.com"
-# # sed 's/^search .*/search numenta.com/g' /etc/resolv.conf -i''
-# cat /etc/resolv.conf
-# host salt.numenta.com
-
 echo "Salt minion_id: $(cat /etc/salt/minion_id)"
-
-# echo "Purging salt minion key data..."
-# rm -fr /etc/salt/pki/minion/*
-
-# echo "Restarting salt minion..."
-# service salt-minion restart
-
-# echo "Wait for master to sign key..."
-# sleep 10
 
 echo
 echo "Running Salt..."

--- a/infrastructure/ami-tools/packer-scripts/install-devtools
+++ b/infrastructure/ami-tools/packer-scripts/install-devtools
@@ -40,4 +40,5 @@ yum install -y cmake \
   libjpeg-turbo-devel \
   libX11-devel \
   libXt-devel \
+  openssl-devel \
   rpm-build

--- a/infrastructure/ami-tools/packer-scripts/install-devtools
+++ b/infrastructure/ami-tools/packer-scripts/install-devtools
@@ -21,11 +21,6 @@
 # ----------------------------------------------------------------------
 # Install devtools
 
-complain() {
-  echo "$@"
-  logger -t ami-bake "$@"
-}
-
 echo "Installing developer tools..."
 echo "Installing devtools-2.repo..."
 cp -v /tmp/devtools-2.repo /etc/yum.repos.d

--- a/infrastructure/ami-tools/packer-scripts/install-salt
+++ b/infrastructure/ami-tools/packer-scripts/install-salt
@@ -33,7 +33,13 @@
 bootstrap_salt(){
   echo "Bootstrapping salt..."
   chmod +x /tmp/bootstrap-salt.sh
-  time /tmp/bootstrap-salt.sh
+
+  if [ -f /tmp/infrastructure_minion_id ]; then
+    echo "Setting minion id.."
+    cat /tmp/infrastructure_minion_id > /etc/salt/minion_id
+  fi
+
+  time /tmp/bootstrap-salt.sh -A salt.numenta.com
 }
 
 prep_instance_for_salt(){
@@ -67,6 +73,7 @@ prep_instance_for_salt(){
 setup_directories(){
   mkdir -p /usr/local/sbin
   mkdir -p /usr/local/bin
+  mkdir -p /etc/salt
 }
 
 prep_instance_for_salt


### PR DESCRIPTION
* Add openssl-dev to AMIs
* Configure salt to use our salt master without us monkeying with '/etc/resolv.conf`
* Preset minion id so salt's bootstrap.sh doesn't attempt to use the default one that isn't preset to be approved on the master
* Turn on debug mode in `bootstrap.sh` so we can see details when it fails
* Add mysql-python to the AMI to try and fix TAUR-851's salt double-run problem
* We only want to purge authorized_keys on grok AMIs so we can pass marketplace acceptance, not every AMI.