### PR TITLE
Revert "TAUR-1272 update rabbitmq-server version to ensure version 3.…

### DIFF
--- a/infrastructure/saltcellar/rabbitmq/init.sls
+++ b/infrastructure/saltcellar/rabbitmq/init.sls
@@ -39,9 +39,7 @@
     - mode: 0755
 
 rabbitmq-server:
-  pkg.installed:
-    - name: rabbitmq-server
-    - version: 3.5.3
+  pkg.installed: []
   service.running:
     - enable: true
     - require:


### PR DESCRIPTION
Version 3.5.3 is not available in the default repo. New repo needs to be added before version 3.5.3 can be installed.