### PR TITLE
TAUR-1272 turn off gpg check because it's failing in salt currently; the gpg key provided by packagecloud is invalid

### DIFF
--- a/infrastructure/saltcellar/rabbitmq/init.sls
+++ b/infrastructure/saltcellar/rabbitmq/init.sls
@@ -44,7 +44,7 @@ rabbitmq_repo:
   pkgrepo.managed:
     - humanname: RabbitMQ Packagecloud Repository
     - baseurl: https://packagecloud.io/rabbitmq/rabbitmq-server/el/6/$basearch
-    - gpgcheck: 1
+    - gpgcheck: 0
     - enabled: True
     - gpgkey: https://packagecloud.io/gpg.key
     - sslverify: 1


### PR DESCRIPTION
CC @unixorn @shantanoo