### PR TITLE
Strip out complain/logline from AMI build packer-scripts

### DIFF
--- a/infrastructure/ami-tools/packer-scripts/cleanup-grok-pipeline-ami
+++ b/infrastructure/ami-tools/packer-scripts/cleanup-grok-pipeline-ami
@@ -37,11 +37,6 @@ CONF_D="${GROK_HOME}/conf"
 UPDATERS_D="${GROK_HOME}/bin/updaters"
 RECEIPTS_D=/etc/grok/updater_statuses
 
-logline() {
-  echo "$@"
-  logger -t ami-bake "$@"
-}
-
 get_password(){
   if [ -r $1 ]; then
     echo $(<$1)  | xargs
@@ -97,7 +92,7 @@ cleanup_grok_conf_files(){
 }
 
 confirm_authorized_keys_removal(){
-  logline "Confirming authorized_keys removal"
+  echo "Confirming authorized_keys removal"
   find /home -name authorized_keys -print
   find /home -iname '*.pub' -print
   find /root -name authorized_keys -print
@@ -106,24 +101,24 @@ confirm_authorized_keys_removal(){
 
 cleanup_grok_logfiles() {
   echo "**********"
-  logline "Cleaning rabbit logs"
+  echo "Cleaning rabbit logs"
   rm -frv "${NUMENTA_D}"/logs/rabbitmq/*
 
   echo "**********"
-  logline "Cleaning updater logs..."
+  echo "Cleaning updater logs..."
   rm -fv "${NUMENTA_D}"/updater/logs/*
 
   echo "**********"
-  logline "Removing firstboot tag files"
+  echo "Removing firstboot tag files"
   rm -fv /etc/grok/firstboot.run /etc/grok/firstboot-root.run
 
   echo "**********"
-  logline "Clearing grok uuid"
+  echo "Clearing grok uuid"
   rm -vf "${CONF_D}/.grok_id"
 
   # Fix MER-2120
   if [ -d "${UPDATERS_D}" ]; then
-    logline "Marking all existing updaters as having been run"
+    echo "Marking all existing updaters as having been run"
     for old_updater in "${UPDATERS_D}"/*
     do
       touch "${RECEIPTS_D}"/$(basename ${old_updater})

--- a/infrastructure/ami-tools/packer-scripts/cleanup-infrastructure-ami
+++ b/infrastructure/ami-tools/packer-scripts/cleanup-infrastructure-ami
@@ -24,23 +24,17 @@
 
 saltConfigured=/etc/numenta/salt_configured
 
-logline() {
-  echo "$@"
-  logger -t ami-bake "$@"
-}
-
 echo
-logline "Infrastructure AMI cleanups"
+echo "Infrastructure AMI cleanups"
 
 service salt-minion stop
 
-logline
-logline "**********"
-logline "Purging salt minion id..."
+echo "**********"
+echo "Purging salt minion id..."
 rm -fr /etc/salt/minion_id
 
-logline "Clearing salt configuration flag"
+echo "Clearing salt configuration flag"
 rm -f "${saltConfigured}"
 
-logline "Purging salt-solo formulas"
+echo "Purging salt-solo formulas"
 rm -fr /srv/salt/*

--- a/infrastructure/ami-tools/packer-scripts/cleanup-webserver-ami
+++ b/infrastructure/ami-tools/packer-scripts/cleanup-webserver-ami
@@ -22,11 +22,6 @@
 
 # Webserver specific cleanups.
 
-complain() {
-  echo "$@"
-  logger -t ami-bake "$@"
-}
-
 echo
 echo "********************************"
 echo "Cleaning webserver AMI candidate"
@@ -39,10 +34,10 @@ rm -frv /opt/numenta/git/live /opt/numenta/git/staging
 
 echo
 echo "********************************"
-complain "Zapping logfiles..."
+echo "Zapping logfiles..."
 logger -t image-cleanup "Zapping logfiles..."
 for logf in /var/log/nginx/*
 do
-  complain "Resetting ${logf}"
+  echo "Resetting ${logf}"
   cat /dev/null > "${logf}"
 done

--- a/infrastructure/ami-tools/packer-scripts/configure-grok-pipeline-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-grok-pipeline-ami
@@ -31,11 +31,6 @@ PRODUCTS="${NUMENTA}/products"
 touch "${AMIBUILD_LOCK}"
 S3_ROOT_URL="https://s3-us-west-2.amazonaws.com/public.numenta.com/yum/x86_64"
 
-complain() {
-  echo "$@"
-  logger -t ami-bake "$@"
-}
-
 splat() {
   # Make it easier to distinguish phases of the script in the scrollback
   echo "
@@ -150,7 +145,7 @@ install-grok() {
   chown -R ec2-user:ec2-user "${PRODUCTS}"
 
   pushd "${PRODUCTS}"
-    complain "Running install-grok.sh"
+    echo "Running install-grok.sh"
 
     ./install-grok.sh "${NUMENTA}/anaconda/lib/python2.7/site-packages" "${NUMENTA}/anaconda/bin"
     if [ $? != 0 ]; then

--- a/infrastructure/ami-tools/packer-scripts/configure-grok-plumbing-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-grok-plumbing-ami
@@ -26,11 +26,6 @@ echo "Marking instance as being an AMI build..."
 AMIBUILD_LOCK=/tmp/baking-ami
 touch "${AMIBUILD_LOCK}"
 
-complain() {
-  echo "$@"
-  logger -t ami-bake "$@"
-}
-
 install-prerequisites-and-update-repos() {
   echo "Purging old grok repo file..."
   rm -f /etc/yum.repos.d/grok.repo

--- a/infrastructure/ami-tools/packer-scripts/configure-webserver-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-webserver-ami
@@ -26,12 +26,6 @@ echo "Marking instance as being an AMI build..."
 AMIBUILD_LOCK=/tmp/baking-ami
 touch "${AMIBUILD_LOCK}"
 
-complain() {
-  echo "$@"
-  logger -t ami-bake "$@"
-}
-
-
 echo "Configuring Salt minion_id"
 echo
 echo "Setting Salt minion_id to webserver-amibake"


### PR DESCRIPTION
If we need to log the output of the individual packer scripts, we should be doing it by piping the stdout/in from our rake task to a file. Writing it to logs on the instance being used for ami bakes isn't effective because it leaves junk on the AMI, and if the AMI bake fails, packer terminates the instance and we won't be able to look at the log files anyway.

@jcasner @shantanoo @oxtopus please CR