### PR TITLE
TAUR-1324 Remove psutil, supervisord from standard infrastructure load

### DIFF
--- a/infrastructure/saltcellar/numenta-python/init.sls
+++ b/infrastructure/saltcellar/numenta-python/init.sls
@@ -60,28 +60,9 @@ anaconda-pip:
     - require:
       - pkg: anaconda-python
 
-# Install this from an S3 wheel so we don't need devtools on everything
-anaconda-psutil:
-  pip.installed:
-    - name: psutil == 1.0.1
-    - bin_env: /opt/numenta/anaconda/bin/pip
-    - watch_in:
-      - cmd: enforce-anaconda-permissions
-    - require:
-      - pkg: anaconda-python
-
 anaconda-setuptools:
   pip.installed:
     - name: setuptools == 18.0.1
-    - bin_env: /opt/numenta/anaconda/bin/pip
-    - watch_in:
-      - cmd: enforce-anaconda-permissions
-    - require:
-      - pkg: anaconda-python
-
-anaconda-supervisor:
-  pip.installed:
-    - name: supervisor == 3.1.3
     - bin_env: /opt/numenta/anaconda/bin/pip
     - watch_in:
       - cmd: enforce-anaconda-permissions

--- a/infrastructure/saltcellar/numenta-python/init.sls
+++ b/infrastructure/saltcellar/numenta-python/init.sls
@@ -78,16 +78,6 @@ anaconda-wheel:
     - require:
       - pkg: anaconda-python
 
-anaconda-yaml:
-  pip.installed:
-    - name: PyYAML == 3.10
-    - bin_env: /opt/numenta/anaconda/bin/pip
-    - watch_in:
-      - cmd: enforce-anaconda-permissions
-    - require:
-      - pip: anaconda-pip
-      - pkg: anaconda-python
-
 # Install a python2.7 symlink so /usr/bin/env python2.7 will work
 python-27-symlink:
   file.symlink:


### PR DESCRIPTION
Instead, let the applications that need them specify the version they need in their requirements.txt.

If we use a third party app that needs them and _doesn't_ have them in their requirements.txt we can make a state that installs the version they need on just the instances using that role.

@jcasner @shantanoo please CR.