### PR TITLE
TAUR-1324 Don't version-lock setuptools

### DIFF
--- a/infrastructure/saltcellar/numenta-python/init.sls
+++ b/infrastructure/saltcellar/numenta-python/init.sls
@@ -62,7 +62,8 @@ anaconda-pip:
 
 anaconda-setuptools:
   pip.installed:
-    - name: setuptools == 18.0.1
+    - name: setuptools
+    - upgrade: True
     - bin_env: /opt/numenta/anaconda/bin/pip
     - watch_in:
       - cmd: enforce-anaconda-permissions


### PR DESCRIPTION
We want whatever is the latest, not 18.0.1 specifically.

@oxtopus, please CR. Also, do you want to make pip install the latest pip too?