### PR TITLE
TAUR-1351 Disable requiretty and !visiblepw in /etc/sudoers

### DIFF
--- a/infrastructure/saltcellar/sudoers-setup/files/sudoers
+++ b/infrastructure/saltcellar/sudoers-setup/files/sudoers
@@ -58,13 +58,13 @@
 # Disable "ssh hostname sudo <cmd>", because it will show the password in clear. 
 #         You have to run "ssh -t hostname sudo <cmd>".
 #
-Defaults    requiretty
+# Defaults    requiretty
 
 #
 # Refuse to run if unable to disable echo on the tty. This setting should also be
 # changed in order to be able to use sudo without a tty. See requiretty above.
 #
-Defaults   !visiblepw
+# Defaults   !visiblepw
 
 #
 # Preserving HOME has security implications since many programs


### PR DESCRIPTION
Given that we already require SSH keys to login and don't permit password authentication, we're already granting passwordless sudo.

Having requiretty enabled doesn't give us any extra security anyway per: https://unix.stackexchange.com/questions/65774/is-it-okay-to-disable-requiretty and !visiblepw is irrelevant since we're granting passwordless sudo and relying on SSH key authentication.

@jcasner, @oxtopus, @shantanoo please CR.