### PR TITLE
TAUR-1371 Add supervisord checker

### DIFF
--- a/taurus.monitoring/setup.py
+++ b/taurus.monitoring/setup.py
@@ -19,6 +19,10 @@ setup(
        "%s.models_monitor.taurus_models_monitor:main" % name),
       ("taurus-metric-order-monitor = "
        "%s.metric_order_monitor.metric_order_monitor:main" % name),
+      ("taurus-server-supervisor-monitor = "
+       "%s.supervisord_monitor.taurus_server_supervisord_monitor:main" % name),
+      ("taurus-collector-supervisor-monitor = "
+       "%s.supervisord_monitor.taurus_collector_supervisord_monitor:main" % name)
     ]
   }
 )

--- a/taurus.monitoring/taurus/monitoring/supervisord_monitor/__init__.py
+++ b/taurus.monitoring/taurus/monitoring/supervisord_monitor/__init__.py
@@ -1,0 +1,20 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------

--- a/taurus.monitoring/taurus/monitoring/supervisord_monitor/supervisord_monitor.py
+++ b/taurus.monitoring/taurus/monitoring/supervisord_monitor/supervisord_monitor.py
@@ -49,7 +49,13 @@ class SupervisorChecker(object):
   parser = OptionParser()
 
   parser.add_option("--monitorConfPath",
-                    help="Specify full path to monitor conf file")
+                    help=("Specify full path to ConfigParser-compatible"
+                          " monitor conf file, containing a [S1] section and"
+                          " the following configuration directives:\n\n"
+                          "MODELS_MONITOR_EMAIL_SENDER_ADDRESS\n"
+                          "MODELS_MONITOR_EMAIL_RECIPIENTS\n"
+                          "MODELS_MONITOR_EMAIL_AWS_REGION\n"
+                          "MODELS_MONITOR_EMAIL_SES_ENDPOINT"))
   parser.add_option("--serverUrl",
                     help="Supervisor API (e.g. http://127.0.0.1:9001)")
 
@@ -63,8 +69,7 @@ class SupervisorChecker(object):
       self.parser.error("Unexpected positional arguments: {}"
                         .format(repr(args)))
 
-    server = xmlrpclib.Server(urljoin(options.serverUrl, "RPC2"))
-    self.server = server
+    self.server = xmlrpclib.Server(urljoin(options.serverUrl, "RPC2"))
 
     confDir = os.path.dirname(options.monitorConfPath)
     confFileName = os.path.basename(options.monitorConfPath)

--- a/taurus.monitoring/taurus/monitoring/supervisord_monitor/supervisord_monitor.py
+++ b/taurus.monitoring/taurus/monitoring/supervisord_monitor/supervisord_monitor.py
@@ -1,0 +1,148 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+from optparse import OptionParser
+import os
+import traceback
+import types
+from urlparse import urljoin
+import xmlrpclib
+
+from nta.utils import error_reporting
+from nta.utils.config import Config
+
+
+
+class SupervisorMonitorError(Exception):
+  pass
+
+
+
+class SupervisorNotRunning(SupervisorMonitorError):
+  pass
+
+
+
+class SupervisorProcessInFatalState(SupervisorMonitorError):
+  pass
+
+
+
+class SupervisorChecker(object):
+  parser = OptionParser()
+
+  parser.add_option("--monitorConfPath",
+                    help="Specify full path to monitor conf file")
+  parser.add_option("--serverUrl",
+                    help="Supervisor API (e.g. http://127.0.0.1:9001)")
+
+  _checks = []
+
+
+  def __init__(self):
+    (options, args) = self.parser.parse_args()
+
+    if args:
+      self.parser.error("Unexpected positional arguments: {}"
+                        .format(repr(args)))
+
+    server = xmlrpclib.Server(urljoin(options.serverUrl, "RPC2"))
+    self.server = server
+
+    confDir = os.path.dirname(options.monitorConfPath)
+    confFileName = os.path.basename(options.monitorConfPath)
+    config = Config(confFileName, confDir)
+
+    self.emailParams = (
+      dict(senderAddress=(
+            config.get("S1", "MODELS_MONITOR_EMAIL_SENDER_ADDRESS")),
+           recipients=config.get("S1", "MODELS_MONITOR_EMAIL_RECIPIENTS"),
+           awsRegion= config.get("S1", "MODELS_MONITOR_EMAIL_AWS_REGION"),
+           sesEndpoint=config.get("S1", "MODELS_MONITOR_EMAIL_SES_ENDPOINT"),
+           awsAccessKeyId=None,
+           awsSecretAccessKey=None))
+
+
+  def checkAll(self):
+    """ Run all previously-registered checks and send an email upon failure
+    """
+    for check in self._checks:
+      try:
+        check(self.server)
+      except Exception as err:
+        error_reporting.sendMonitorErrorEmail(
+          monitorName=__name__ + ":" + check.__name__,
+          resourceName=repr(self.server),
+          message=traceback.format_exc(),
+          params=self.emailParams)
+
+
+  @classmethod
+  def registerCheck(cls, fn):
+    """ Function decorator to register an externally defined function as a
+    check.  Function must accept a ServerProxy instance as its first
+    argument.
+    """
+    cls._checks.append(fn)
+
+
+
+@SupervisorChecker.registerCheck
+def checkSupervisordState(server):
+  """ Check that supervisord is running
+  """
+  state = server.supervisor.getState()
+  if not isinstance(state, types.DictType):
+    raise SupervisorMonitorError("Unexpected response from"
+                                 " `server.supervisor.getState()`: {}"
+                                 .format(repr(state)))
+
+  if state.get("statename") != "RUNNING":
+    raise SupervisorNotRunning("Supervisor does not appear to be running:"
+                               "{}".format(repr(state)))
+
+
+@SupervisorChecker.registerCheck
+def checkSupervisorProcesses(server):
+  """ Check that there are no processes in a 'FATAL' state.
+  """
+  processes = server.supervisor.getAllProcessInfo()
+
+  if not isinstance(processes, types.ListType):
+    raise SupervisorMonitorError("Unexpected response from"
+                                 " `server.supervisor.getAllProcessInfo()`: {}"
+                                 .format(repr(processes)))
+
+  for process in processes:
+    if process.get("statename") == "FATAL":
+      logTail = server.supervisor.tailProcessLog(
+        process["group"] + ":" + process["name"], -2048, 2048)
+
+      errMessage = ("{group}:{name} is in a FATAL state: {description}"
+                    .format(group=process.get("group"),
+                            name=process.get("name"),
+                            description=process.get("description"))) + (
+                    "\n\nLast 2048 bytes of log:" +
+                    "\n\n=======================\n\n" +
+                    logTail[0] +
+                    "\n\n=======================\n")
+
+      raise SupervisorProcessInFatalState(errMessage)
+

--- a/taurus.monitoring/taurus/monitoring/supervisord_monitor/taurus_collector_supervisord_monitor.py
+++ b/taurus.monitoring/taurus/monitoring/supervisord_monitor/taurus_collector_supervisord_monitor.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from taurus.monitoring.supervisord_monitor.supervisord_monitor import (
+  SupervisorChecker)
+
+
+
+"""
+Implement Taurus-specific checks using the template below.  For now, don't
+do anything beyond the standard high-level supervisor checks (i.e. that
+supervisor is running and no processes are in a FATAL state)
+
+@SupervisorChecker.registerCheck
+def checkFoo(checker):
+  # Implement Taurus-specific supervisor-related check here
+"""
+
+
+
+def main():
+  SupervisorChecker().checkAll()
+
+
+
+if __name__ == "__main__":
+  main()

--- a/taurus.monitoring/taurus/monitoring/supervisord_monitor/taurus_server_supervisord_monitor.py
+++ b/taurus.monitoring/taurus/monitoring/supervisord_monitor/taurus_server_supervisord_monitor.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from taurus.monitoring.supervisord_monitor.supervisord_monitor import (
+  SupervisorChecker)
+
+
+
+"""
+Implement Taurus-specific checks using the template below.  For now, don't
+do anything beyond the standard high-level supervisor checks (i.e. that
+supervisor is running and no processes are in a FATAL state)
+
+@SupervisorChecker.registerCheck
+def checkFoo(checker):
+  # Implement Taurus-specific supervisor-related check here
+"""
+
+
+
+def main():
+  SupervisorChecker().checkAll()
+
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Adds an implementation for checking supervisor status, including whether or not there are any services in a FATAL state and sends an email with the details.  Intended to be run as a periodic cron job.

Usage:

```
taurus-server-supervisor-monitor --serverUrl=http://HOST:PORT --monitorConfPath=REDACTED
taurus-collector-supervisor-monitor --serverUrl=http://HOST:PORT --monitorConfPath=REDACTED
```

cc @unixorn 