### PR TITLE
TAUR-1373 Upstream updated to 3.5.4, 3.5.3 is no longer available

### DIFF
--- a/infrastructure/saltcellar/rabbitmq/init.sls
+++ b/infrastructure/saltcellar/rabbitmq/init.sls
@@ -55,7 +55,7 @@ rabbitmq_repo:
 rabbitmq-server:
   pkg.installed:
     - name: rabbitmq-server
-    - version: 3.5.3-1
+    - version: 3.5.4-1
   service.running:
     - enable: true
     - require:


### PR DESCRIPTION
We'll need to update the carbonite repo to prevent having to make this kind of last minute version update [TAUR-1382](https://jira.numenta.com/browse/TAUR-1382).

@oxtopus @jcasner please CR