### PR TITLE
TAUR-1397 Helper utils for remediating a production issue in which st…

### DIFF
--- a/taurus.metric_collectors/setup.py
+++ b/taurus.metric_collectors/setup.py
@@ -29,6 +29,7 @@ setup(
       "taurus-collectors-set-opmode = %s.set_collectors_opmode:main" % name,
       "taurus-collectors-set-rabbitmq = %s.set_rabbitmq_login:main" % name,
       "taurus-create-models = %s.create_models:main" % name,
+      "taurus-delete-metric = %s.delete_metric:main" % name,
       "taurus-unmonitor-metrics = %s.unmonitor_metrics:main" % name,
       "taurus-monitor-metrics = %s.monitor_metrics:main" % name,
       ("taurus-check-twitter-screen-names = "

--- a/taurus.metric_collectors/taurus/metric_collectors/delete_metric.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/delete_metric.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+""" Delete specific metric on the given destination HTM server """
+
+import logging
+from optparse import OptionParser
+import os
+import sys
+
+from taurus.metric_collectors import logging_support, metric_utils
+
+
+
+DEFAULT_HTM_SERVER = os.environ.get("TAURUS_HTM_SERVER")
+
+
+
+g_log = logging.getLogger("metric_collectors.unmonitor_metrics")
+
+
+
+def _parseArgs():
+  """
+  :returns: dict of arg names and values:
+    htmServer
+    apiKey
+    metricName
+  """
+  helpString = (
+    "%prog [options] [metric name]\n\n"
+    "Deletes specific metric on an HTM server.")
+
+  parser = OptionParser(helpString)
+
+  parser.add_option(
+    "--server",
+    action="store",
+    type="string",
+    dest="htmServer",
+    default=DEFAULT_HTM_SERVER,
+    help="Hostname or IP address of server running HTM Engine API to create "
+    "models [default: %default]")
+
+  parser.add_option(
+    "--apikey",
+    action="store",
+    type="string",
+    dest="apiKey",
+    help="API Key of HTM Engine")
+
+  options, metricNames = parser.parse_args()
+
+  if len(metricNames) != 1:
+    msg = ("Unexpected additional arguments"
+           if len(metricNames) > 1
+           else "Missing metric name argument")
+    g_log.error(msg)
+    parser.error(msg)
+
+  if not options.htmServer:
+    msg = ("Missing or empty Hostname or IP address of server running HTM "
+           "Engine API")
+    g_log.error(msg)
+    parser.error(msg)
+
+  if not options.apiKey:
+    msg = "Missing or empty API Key of HTM Engine"
+    g_log.error(msg)
+    parser.error(msg)
+
+
+  return dict(
+    htmServer=options.htmServer,
+    apiKey=options.apiKey,
+    metricName = metricNames[0]
+  )
+
+
+
+def main():
+  logging_support.LoggingSupport.initTool()
+
+  try:
+    options = _parseArgs()
+    g_log.info("Running %s with options=%r", sys.argv[0], options)
+
+    for metric in metric_utils.getAllCustomMetrics(host=options["htmServer"],
+                                                   apiKey=options["apiKey"]):
+      if metric["name"] == options["metricName"]:
+        metric_utils.deleteMetric(host=options["htmServer"],
+                                  apiKey=options["apiKey"],
+                                  metricName=metric["name"])
+
+        g_log.info("Deleted metric=%s", metric["name"])
+        break
+
+  except SystemExit as e:
+    if e.code != 0:
+      g_log.exception("delete_metric failed")
+    raise
+  except Exception:
+    g_log.exception("delete_metric failed")
+    raise
+
+
+
+if __name__ == "__main__":
+  main()

--- a/taurus.metric_collectors/taurus/metric_collectors/reset_emitted_status.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/reset_emitted_status.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+""" Reset emitted status for a stock symbol so that the collector can
+back-fill a previously deleted metric using data available in collectorsdb """
+
+import argparse
+import random
+
+from taurus.metric_collectors import collectorsdb
+from taurus.metric_collectors.collectorsdb import schema
+
+
+
+def deleteFromEmitted(conn, table, symbol):
+  print ("Deleting `{}` from `{}` table of `{}` database"
+         .format(symbol, table.name, str(conn.engine)))
+  return conn.execute(table.delete().where(table.c.symbol==symbol))
+
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--symbol", required=True)
+
+  args = parser.parse_args()
+
+  expectedAnswer = "Yes-%s" % (random.randint(1, 30),)
+
+  with collectorsdb.engineFactory().begin() as conn:
+    answer = raw_input(
+      "Attention!  You are about to reset the emitted status for the \"{}\""
+      " stock symbol at {}.\n"
+      "\n"
+      "To back out immediately without making any changes, feel free to type "
+      "anything but \"{}\" in the prompt below, and press return.\n"
+      "\n"
+      "Are you sure you want to continue? ".format(args.symbol,
+                                                   str(conn.engine),
+                                                   str(expectedAnswer)))
+
+    if answer.strip() != expectedAnswer:
+      print "Aborting - Wise choice, my friend. Bye."
+      return 1
+
+    deleteFromEmitted(conn, schema.emittedStockPrice, args.symbol)
+    deleteFromEmitted(conn, schema.emittedStockVolume, args.symbol)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
…ock data is missing.

This adds the `taurus-delete-metric` command, for deleting a metric from a taurus server.  It also adds a new script (without a console entry point) to reset the emitted status for a stock symbol.

cc @vitaly-krugl please review asap for P1 issue