### PR TITLE
UNI-148 #comment Init working Client/Server code for Files, Models, DBs.

### DIFF
--- a/unicorn/frontend/browser/app.js
+++ b/unicorn/frontend/browser/app.js
@@ -34,23 +34,22 @@ import 'babel/polyfill';  // es6/7 polyfill Array.from()
 
 import Fluxible from 'fluxible';
 import FluxibleReact from 'fluxible-addons-react';
-import isElectronRenderer from 'is-electron-renderer';
 import React from 'react';
 import tapEventInject from 'react-tap-event-plugin';
 
 // internals
 
-if(isElectronRenderer) { // desktop
-  var remote = require('remote');
-  var fileClient = remote.require('./lib/FileServer');
-}
-else { // web
-  // var fileClient = require('./browser/lib/FileClientHTTPRequest');
-}
-
 import FooAction from './actions/foo';
 import FooComponent from './components/foo';
 import FooStore from './stores/foo';
+
+import DatabaseClient from './lib/DatabaseClient';
+import FileClient from './lib/FileClient';
+import ModelClient from './lib/ModelClient';
+
+var databaseClient = new DatabaseClient();
+var fileClient = new FileClient();
+var modelClient = new ModelClient();
 
 let app;
 let context;
@@ -61,7 +60,7 @@ let FooView;
 
 document.addEventListener('DOMContentLoaded', () => {
 
-  // FileClient/Server test
+  // working example/test of FileClient/Server over IPC
   fileClient.getFiles(function(error, files) {
     if(error) throw new Error('cannot get list of files');
     console.log('sample files:', files);

--- a/unicorn/frontend/browser/components/foo.jsx
+++ b/unicorn/frontend/browser/components/foo.jsx
@@ -38,7 +38,7 @@ import SvgIconContentAdd from 'material-ui/lib/svg-icons/content/add'
 let Theme = new Material.Styles.ThemeManager();
 
 let {
-  Card, CardHeader, CardText, FloatingActionButton, FontIcon, LeftNav
+  Card, CardText, FloatingActionButton, FontIcon, LeftNav
 } = Material;
 
 let menuItems = [
@@ -91,7 +91,6 @@ module.exports = React.createClass({
     return (
       <div>
         <Card style={{ marginLeft: '256px' }}>
-          <CardHeader title="Title" subtitle="Subtitle" />
           <CardText>
             <h1>Welcome</h1>
             <FloatingActionButton onClick={this._onClick}>

--- a/unicorn/frontend/browser/lib/DatabaseClient.js
+++ b/unicorn/frontend/browser/lib/DatabaseClient.js
@@ -22,46 +22,33 @@
 
 
 /**
- * Unicorn: FileServer - Respond to a FileClient over IPC, sharing our access to
- *  the Node/io.js layer of filesystem, so client can CRUD files.
- *
- * Must be ES5 for now, Electron's `remote` doesn't seem to like ES6 Classes!
+ * Unicorn: DatabaseClient - Talk to a DatabaseServer over IPC or HTTP, gaining
+ *  access to the Node/io.js layer of filesystem, so we can CRUD against a
+ *  flat-file database. Connects via HTTP or IPC adapter. DatabaseClientIPC
+ *  adpater is currently a pseudo-library, using the magic of Electron's
+ *  `remote` module.
  */
 
 // externals
 
-import fs from 'fs';
-import path from 'path';
+import isElectronRenderer from 'is-electron-renderer';
+import remote from 'remote';
 
 // internals
 
-const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
+import DatabaseClientHTTP from './DatabaseClientHTTP';
+
+let DatabaseClient;
 
 
 // MAIN
-
-/**
- *
- */
-var FileServer = function () {
-  this.FILE_PATH = FILE_PATH;
-};
-
-/**
- *
- */
-FileServer.prototype.getFile = function (filename, callback) {
-  fs.readFile(path.join(this.FILE_PATH, filename), callback);
-};
-
-/**
- *
- */
-FileServer.prototype.getFiles = function (callback) {
-  fs.readdir(this.FILE_PATH, callback);
-};
+if(isElectronRenderer && remote) { // desktop
+  DatabaseClient = remote.require('./lib/DatabaseServer'); // pseduo-DatabaseClientIPC
+}
+else { // web
+  DatabaseClient = DatabaseClientHTTP;
+}
 
 
-// EXPORTS
-
-module.exports = FileServer;
+// EXPORT
+export default DatabaseClient;

--- a/unicorn/frontend/browser/lib/DatabaseClientHTTP.js
+++ b/unicorn/frontend/browser/lib/DatabaseClientHTTP.js
@@ -22,46 +22,22 @@
 
 
 /**
- * Unicorn: FileServer - Respond to a FileClient over IPC, sharing our access to
- *  the Node/io.js layer of filesystem, so client can CRUD files.
- *
- * Must be ES5 for now, Electron's `remote` doesn't seem to like ES6 Classes!
+ * Unicorn: DatabaseClientHTTP - HTTP Adapter (one of many) for DatabaseClient
+ *  (talks to a DatabaseServer) to access the Node/io.js flat file
+ *  database layer for heavy persistence.
  */
-
-// externals
-
-import fs from 'fs';
-import path from 'path';
-
-// internals
-
-const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
 
 
 // MAIN
 
-/**
- *
- */
-var FileServer = function () {
-  this.FILE_PATH = FILE_PATH;
-};
+export default class DatabaseClientHTTP {
 
-/**
- *
- */
-FileServer.prototype.getFile = function (filename, callback) {
-  fs.readFile(path.join(this.FILE_PATH, filename), callback);
-};
+  constructor() {
+    this.uhh = 'http';
+  }
 
-/**
- *
- */
-FileServer.prototype.getFiles = function (callback) {
-  fs.readdir(this.FILE_PATH, callback);
-};
+  example(callback) {
+    callback(null, { result: 'uhh_is_' + this.uhh });
+  }
 
-
-// EXPORTS
-
-module.exports = FileServer;
+}

--- a/unicorn/frontend/browser/lib/FileClient.js
+++ b/unicorn/frontend/browser/lib/FileClient.js
@@ -22,46 +22,34 @@
 
 
 /**
- * Unicorn: FileServer - Respond to a FileClient over IPC, sharing our access to
- *  the Node/io.js layer of filesystem, so client can CRUD files.
- *
- * Must be ES5 for now, Electron's `remote` doesn't seem to like ES6 Classes!
+ * Unicorn: FileClient - Talk to a FileServer over IPC or HTTP, gaining
+ *  access to the Node/io.js layer of filesystem, so we can CRUD files.
+ *  Connects via HTTP or IPC adapter. FileClientIPC adpater is currently a
+ *  pseudo-library, using the magic of Electron's `remote` module.
  */
 
 // externals
 
-import fs from 'fs';
-import path from 'path';
+import isElectronRenderer from 'is-electron-renderer';
+import remote from 'remote';
 
 // internals
 
-const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
+import FileClientHTTP from './FileClientHTTP';
+
+let FileClient;
 
 
 // MAIN
 
-/**
- *
- */
-var FileServer = function () {
-  this.FILE_PATH = FILE_PATH;
-};
-
-/**
- *
- */
-FileServer.prototype.getFile = function (filename, callback) {
-  fs.readFile(path.join(this.FILE_PATH, filename), callback);
-};
-
-/**
- *
- */
-FileServer.prototype.getFiles = function (callback) {
-  fs.readdir(this.FILE_PATH, callback);
-};
+if(isElectronRenderer && remote) { // desktop
+  FileClient = remote.require('./lib/FileServer'); // pseduo-FileClientIPC
+}
+else { // web
+  FileClient = FileClientHTTP;
+}
 
 
-// EXPORTS
+// EXPORT
 
-module.exports = FileServer;
+export default FileClient;

--- a/unicorn/frontend/browser/lib/FileClientHTTP.js
+++ b/unicorn/frontend/browser/lib/FileClientHTTP.js
@@ -22,46 +22,32 @@
 
 
 /**
- * Unicorn: FileServer - Respond to a FileClient over IPC, sharing our access to
- *  the Node/io.js layer of filesystem, so client can CRUD files.
- *
- * Must be ES5 for now, Electron's `remote` doesn't seem to like ES6 Classes!
+ * Unicorn: FileClientHTTP - HTTP Adapter (one of many) for FileClient (talks to
+ *  a FileServer) to access the Node/io.js layer of filesystem, so we can
+ *  CRUD files.
  */
-
-// externals
-
-import fs from 'fs';
-import path from 'path';
-
-// internals
-
-const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
 
 
 // MAIN
 
-/**
- *
- */
-var FileServer = function () {
-  this.FILE_PATH = FILE_PATH;
-};
+export default class FileClientHTTP {
 
-/**
- *
- */
-FileServer.prototype.getFile = function (filename, callback) {
-  fs.readFile(path.join(this.FILE_PATH, filename), callback);
-};
+  /**
+   *
+   */
+  constructor() {
+  }
 
-/**
- *
- */
-FileServer.prototype.getFiles = function (callback) {
-  fs.readdir(this.FILE_PATH, callback);
-};
+  /**
+   *
+   */
+  getFile() {
+  }
 
+  /**
+   *
+   */
+  getFiles() {
+  }
 
-// EXPORTS
-
-module.exports = FileServer;
+}

--- a/unicorn/frontend/browser/lib/ModelClient.js
+++ b/unicorn/frontend/browser/lib/ModelClient.js
@@ -22,46 +22,34 @@
 
 
 /**
- * Unicorn: FileServer - Respond to a FileClient over IPC, sharing our access to
- *  the Node/io.js layer of filesystem, so client can CRUD files.
- *
- * Must be ES5 for now, Electron's `remote` doesn't seem to like ES6 Classes!
+ * Unicorn: ModelClient - Talk to a ModelServer over IPC or HTTP, gaining
+ *  access to the Backend NuPIC Model Runner. Connects via HTTP or IPC adapter.
+ *  ModelClientIPC adpater is currently a pseudo-library, using the magic of
+ *  Electron's `remote` module.
  */
 
 // externals
 
-import fs from 'fs';
-import path from 'path';
+import isElectronRenderer from 'is-electron-renderer';
+import remote from 'remote';
 
 // internals
 
-const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
+import ModelClientHTTP from './ModelClientHTTP';
+
+let ModelClient;
 
 
 // MAIN
 
-/**
- *
- */
-var FileServer = function () {
-  this.FILE_PATH = FILE_PATH;
-};
-
-/**
- *
- */
-FileServer.prototype.getFile = function (filename, callback) {
-  fs.readFile(path.join(this.FILE_PATH, filename), callback);
-};
-
-/**
- *
- */
-FileServer.prototype.getFiles = function (callback) {
-  fs.readdir(this.FILE_PATH, callback);
-};
+if(isElectronRenderer && remote) { // desktop
+  ModelClient = remote.require('./lib/ModelServer'); // pseduo-ModelClientIPC
+}
+else { // web
+  ModelClient = ModelClientHTTP;
+}
 
 
-// EXPORTS
+// EXPORT
 
-module.exports = FileServer;
+export default ModelClient;

--- a/unicorn/frontend/browser/lib/ModelClientHTTP.js
+++ b/unicorn/frontend/browser/lib/ModelClientHTTP.js
@@ -22,46 +22,43 @@
 
 
 /**
- * Unicorn: FileServer - Respond to a FileClient over IPC, sharing our access to
- *  the Node/io.js layer of filesystem, so client can CRUD files.
- *
- * Must be ES5 for now, Electron's `remote` doesn't seem to like ES6 Classes!
+ * Unicorn: ModelClientHTTP - HTTP Adapter (one of many) for ModelClient (talks
+ *  to a ModelServer) to access the backend Py + NuPIC + Model process runner.
  */
-
-// externals
-
-import fs from 'fs';
-import path from 'path';
-
-// internals
-
-const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
 
 
 // MAIN
 
-/**
- *
- */
-var FileServer = function () {
-  this.FILE_PATH = FILE_PATH;
-};
+export default class ModelClientHTTP {
 
-/**
- *
- */
-FileServer.prototype.getFile = function (filename, callback) {
-  fs.readFile(path.join(this.FILE_PATH, filename), callback);
-};
+  /**
+   *
+   */
+  constructor() {
+  }
 
-/**
- *
- */
-FileServer.prototype.getFiles = function (callback) {
-  fs.readdir(this.FILE_PATH, callback);
-};
+  /**
+   *
+   */
+  addModel() {
+  }
 
+  /**
+   *
+   */
+  getModel() {
+  }
 
-// EXPORTS
+  /**
+   *
+   */
+  getModels() {
+  }
 
-module.exports = FileServer;
+  /**
+   *
+   */
+  removeModels() {
+  }
+
+}

--- a/unicorn/frontend/lib/DatabaseServer.js
+++ b/unicorn/frontend/lib/DatabaseServer.js
@@ -22,20 +22,11 @@
 
 
 /**
- * Unicorn: FileServer - Respond to a FileClient over IPC, sharing our access to
- *  the Node/io.js layer of filesystem, so client can CRUD files.
+ * Unicorn: DatabaseServer - Respond to a DatabaseClient over IPC, sharing our
+ *  access to a file-based Node/io.js database system, for heavy persistence.
  *
  * Must be ES5 for now, Electron's `remote` doesn't seem to like ES6 Classes!
  */
-
-// externals
-
-import fs from 'fs';
-import path from 'path';
-
-// internals
-
-const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
 
 
 // MAIN
@@ -43,25 +34,18 @@ const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
 /**
  *
  */
-var FileServer = function () {
-  this.FILE_PATH = FILE_PATH;
+var DatabaseServer = function () {
+  this.uhh = 'ipc';
 };
 
 /**
  *
  */
-FileServer.prototype.getFile = function (filename, callback) {
-  fs.readFile(path.join(this.FILE_PATH, filename), callback);
-};
-
-/**
- *
- */
-FileServer.prototype.getFiles = function (callback) {
-  fs.readdir(this.FILE_PATH, callback);
+DatabaseServer.prototype.example = function(callback) {
+  callback(null, { result: 'uhh_is_' + this.uhh });
 };
 
 
 // EXPORTS
 
-module.exports = FileServer;
+module.exports = DatabaseServer;

--- a/unicorn/frontend/lib/ModelServer.js
+++ b/unicorn/frontend/lib/ModelServer.js
@@ -22,20 +22,11 @@
 
 
 /**
- * Unicorn: FileServer - Respond to a FileClient over IPC, sharing our access to
- *  the Node/io.js layer of filesystem, so client can CRUD files.
+ * Unicorn: ModelServer - Respond to a ModelClient over IPC, sharing our access
+ *  to Unicorn Backend Model Runner python and NuPIC processes.
  *
  * Must be ES5 for now, Electron's `remote` doesn't seem to like ES6 Classes!
  */
-
-// externals
-
-import fs from 'fs';
-import path from 'path';
-
-// internals
-
-const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
 
 
 // MAIN
@@ -43,25 +34,47 @@ const FILE_PATH = path.join('frontend', 'samples'); // @TODO move path to config
 /**
  *
  */
-var FileServer = function () {
-  this.FILE_PATH = FILE_PATH;
+var ModelServer = function () {
+  this.models = {};
 };
 
 /**
  *
  */
-FileServer.prototype.getFile = function (filename, callback) {
-  fs.readFile(path.join(this.FILE_PATH, filename), callback);
+ModelServer.prototype.addModel = function (model, callback) {
+  // spawn() NuPIC process here
+  this.models[model.modelId] = model;
+  // callback(error, null);
+  callback(null, { model: this.models[model.modelId] });
 };
 
 /**
  *
  */
-FileServer.prototype.getFiles = function (callback) {
-  fs.readdir(this.FILE_PATH, callback);
+ModelServer.prototype.getModels = function (callback) {
+  // callback(error, null);
+  callback(null, { models: this.models });
+};
+
+/**
+ *
+ */
+ModelServer.prototype.getModel = function (modelId, callback) {
+  // callback(error, null);
+  callback(null, { model: this.models[modelId] });
+};
+
+/**
+ *
+ */
+ModelServer.prototype.removeModel = function (modelId, callback) {
+  // kill spawn() of NuPIC process here
+  delete this.models[model.modelId];
+  // callback(error, null);
+  callback(null, { modelId: modelId });
 };
 
 
 // EXPORTS
 
-module.exports = FileServer;
+module.exports = ModelServer;

--- a/unicorn/gulpfile.babel.js
+++ b/unicorn/gulpfile.babel.js
@@ -116,7 +116,7 @@ gulp.task('webpack', ()  => {
       module: {
         loaders: [{
           test: /\.(js|jsx)$/,
-          loaders: [ 'react-hot', 'babel-loader?stage=1' ],
+          loaders: [ 'babel-loader?stage=1' ],
           exclude: /node_modules/
         }, {
           test: /\.json$/,
@@ -127,7 +127,6 @@ gulp.task('webpack', ()  => {
         filename: 'bundle.js'
       },
       plugins: [
-        new webpack.HotModuleReplacementPlugin(),
         new webpack.IgnorePlugin(/vertx/)  // @TODO remove in fluxible 4.x
       ],
       resolve: {

--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -61,8 +61,8 @@
     "react-tap-event-plugin": "0.1.7"
   },
   "devDependencies": {
-    "babel": "5.8.21",
-    "babel-core": "5.8.22",
+    "babel": "5.8.23",
+    "babel-core": "5.8.23",
     "babel-eslint": "4.1.0",
     "babel-loader": "5.3.2",
     "babel-plugin-typecheck": "1.2.0",
@@ -74,10 +74,10 @@
     "gulp": "3.9.0",
     "gulp-util": "3.0.6",
     "http-server": "0.8.0",
+    "json-loader": "0.5.2",
     "mocha": "2.2.5",
     "mocha-casperjs": "0.5.4",
     "node-inspector": "0.12.2",
-    "react-hot-loader": "1.2.9",
     "webpack": "1.12.0",
     "webpack-stream": "2.1.0"
   }


### PR DESCRIPTION
UNI-148 #comment Init working Client/Server code for Files, Models, DBs.
Client IPC adapters are virtual using Electron's `remote`, but could be easily
specified and extended in the future.  These are sadly currently in ES5, as `remote` can't seem
to understand ES6 Classes and -some- syntax, couldn't figure out why.

Demo Client HTTP adapters also created to illustrate a REST API backend.

FileClient/Server still working end-to-end.

Also Bump a few pkg ver #'s.

https://jira.numenta.com/browse/UNI-148
https://jira.numenta.com/browse/UNI-150
https://jira.numenta.com/browse/UNI-153
https://jira.numenta.com/browse/UNI-154

FYI @lscheinkman @marionleborgne @jcasner 
