### PR TITLE
Bring nupic requirement up to 0.2.12 as well as make py.test requirem…

### DIFF
--- a/grok/requirements.txt
+++ b/grok/requirements.txt
@@ -2,7 +2,7 @@
 dbutils==1.1
 numpy==1.9.2
 mysql-python==1.2.5
-pytest==2.4.2
+pytest==2.5.1
 pytest-cov==1.6
 pytest-xdist==1.8
 unittest2==0.5.1

--- a/htmengine/requirements.txt
+++ b/htmengine/requirements.txt
@@ -4,6 +4,6 @@ sqlalchemy==0.9.4
 msgpack-python==0.3.0
 validictory==0.9.1
 mysql-python==1.2.5
-nupic==0.2.11
+nupic==0.2.12
 nta.utils>=0.0.0
 psutil==1.0.1

--- a/nta.utils/requirements.txt
+++ b/nta.utils/requirements.txt
@@ -7,6 +7,6 @@ sqlalchemy==0.9.4
 # required by tests
 mock==1.0.1
 unittest2==0.5.1
-pytest==2.4.2
+pytest==2.5.1
 pytest-cov==1.6
 pytest-xdist==1.8


### PR DESCRIPTION
…ent consistent

When you're ready with a nupic@0.2.12 release, @rhyolight, @jcasner, and @scottpurdy 