### PR TITLE
TAUR-1383 Make supervisord listen on all interfaces

### DIFF
--- a/taurus.metric_collectors/conf/supervisord.conf
+++ b/taurus.metric_collectors/conf/supervisord.conf
@@ -2,7 +2,7 @@
 file=%(here)s/../supervisor.sock
 
 [inet_http_server]
-port=127.0.0.1:8001
+port=*:8001
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/taurus/conf/supervisord.conf
+++ b/taurus/conf/supervisord.conf
@@ -10,7 +10,7 @@
 file=%(here)s/../taurus-supervisor.sock   ; (the path to the socket file)
 
 [inet_http_server]
-port=127.0.0.1:9001
+port=*:9001
 
 [supervisord]
 environment=APPLICATION_CONFIG_PATH=/opt/numenta/taurus/conf


### PR DESCRIPTION
@oxtopus this is allow remote monitoring of the taurus server and collector. The security groups in EC2 will limit access to 9001 on the taurus instances to the monitoring server.

cc: @vitaly-krugl 

@jcasner please CR