### PR TITLE
ENG-32 Added timeout in HTTP requests in xignite stock and news agents.

### DIFF
--- a/taurus.metric_collectors/taurus/metric_collectors/xignite/xignite_security_news_agent.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/xignite/xignite_security_news_agent.py
@@ -84,6 +84,8 @@ _EMITTED_NEWS_VOLUME_SAMPLE_TRACKER_KEY = "xignite-security-news-volume"
 _NEWS_VOLUME_METRIC_PROVIDER = "xignite-security-news"
 
 
+_HTTP_INACTIVITY_TIMEOUT_SEC = 240
+
 
 NewsVolumeMetricSpec = namedtuple(
   "NewsVolumeMetricSpec", "metric symbol")
@@ -159,7 +161,7 @@ def _httpGetWithRetries(session, url, params):
   :returns: requests.models.Response instance. see requests.Session.get for
     details
   """
-  return session.get(url, params=params)
+  return session.get(url, params=params, timeout=_HTTP_INACTIVITY_TIMEOUT_SEC)
 
 
 
@@ -528,7 +530,7 @@ class _HistoricalNewsTaskBase(object):
 
       # Re-insert news after resolving IntegrityError
       return saveNews()
-      
+
 
 
 

--- a/taurus.metric_collectors/taurus/metric_collectors/xignite/xignite_stock_agent.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/xignite/xignite_stock_agent.py
@@ -60,6 +60,8 @@ from taurus.metric_collectors.xignite import xignite_agent_utils
 
 
 
+URLOPEN_TIMEOUT_SEC = 240
+
 DATE_FMT = "%m/%d/%Y %I:%M:%S %p"
 DEFAULT_BARLENGTH = 5
 DEFAULT_SERVER = os.environ.get("TAURUS_HTM_SERVER", "127.0.0.1")
@@ -279,7 +281,8 @@ def getData(symbol, apitoken, barlength, startTime, endTime, fields):
 
   queryString = urllib.urlencode(query)
 
-  response = urllib2.urlopen(_API_URL + queryString)
+  response = urllib2.urlopen(_API_URL + queryString,
+                             timeout=URLOPEN_TIMEOUT_SEC)
 
   return json.loads(response.read())
 

--- a/taurus.metric_collectors/tests/integration/metric_utils_test.py
+++ b/taurus.metric_collectors/tests/integration/metric_utils_test.py
@@ -58,6 +58,14 @@ class MetricUtilsTestCase(unittest.TestCase):
       in random.sample(metric_utils.getMetricsConfiguration().items(), 3)
     }
 
+    for resName, resVal in metrics.iteritems():
+      for metricName in resVal["metrics"]:
+        self.addCleanup(requests.delete,
+                        "https://%s/_metrics/custom/%s" % (host, metricName),
+                        auth=(apikey, ""),
+                        verify=False)
+
+
     with patch("taurus.metric_collectors.metric_utils.getMetricsConfiguration",
                return_value=metrics,
                spec_set=metric_utils.getMetricsConfiguration):
@@ -66,10 +74,6 @@ class MetricUtilsTestCase(unittest.TestCase):
     allModels = metric_utils.getAllModels(host, apikey)
 
     for model in createdModels:
-      self.addCleanup(requests.delete,
-                      "https://%s/_metrics/custom/%s" % (host, model["name"]),
-                      auth=(apikey, ""),
-                      verify=False)
       remoteModel = metric_utils.getOneModel(host, apikey, model["uid"])
       self.assertDictEqual(remoteModel, model)
       self.assertIn(model, allModels)


### PR DESCRIPTION
ENG-32 Added timeout in HTTP requests in xignite stock and news agents.
ENG-32 Fixed clean-up logic in the testCreateAllModels test method in integration/metric_utils_test.py.