### PR TITLE
Remove stale CentOS 6 git package

### DIFF
--- a/infrastructure/saltcellar/nta-nucleus/packages.sls
+++ b/infrastructure/saltcellar/nta-nucleus/packages.sls
@@ -56,3 +56,12 @@ human-use-packages:
       - telnet
       - tmux
       - vim-enhanced
+
+remove-deprecated-packages:
+  pkg:
+    - removed
+    - pkgs:
+      - git
+    - require:
+      - pkg: core-packages
+      - pkg: human-use-packages


### PR DESCRIPTION
We install an up-to-date version of git in our nta-git package; CentOS 6 has a very stale version, so remove it.

@jcasner @shantanoo please CR