### PR TITLE
Use 0.0.0.0 instead of * in supervisord.conf port setting

### DIFF
--- a/taurus.metric_collectors/conf/supervisord.conf
+++ b/taurus.metric_collectors/conf/supervisord.conf
@@ -2,7 +2,7 @@
 file=%(here)s/../supervisor.sock
 
 [inet_http_server]
-port=*:8001
+port=0.0.0.0:8001
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/taurus/conf/supervisord.conf
+++ b/taurus/conf/supervisord.conf
@@ -10,7 +10,7 @@
 file=%(here)s/../taurus-supervisor.sock   ; (the path to the socket file)
 
 [inet_http_server]
-port=*:9001
+port=0.0.0.0:9001
 
 [supervisord]
 environment=APPLICATION_CONFIG_PATH=/opt/numenta/taurus/conf


### PR DESCRIPTION
Address @oxtopus's feedback on [numenta-apps/pull/299](https://github.com/numenta/numenta-apps/pull/299)

We only use IPv4, and given that the way we're using EC2 triggers undesired behavior in supervisord let's go with a configuration that works reliably.

@oxtopus please CR
cc: @jcasner 