### PR TITLE
ENG-26 Switch (float, int) variant in testFeedInputGetOutput back to just checking for float

### DIFF
--- a/unicorn/tests/py/integration/model_runner_test.py
+++ b/unicorn/tests/py/integration/model_runner_test.py
@@ -181,7 +181,7 @@ class ModelRunnerTestCase(unittest.TestCase):
         rowIndex, anomalyLikelihood = json.loads(outputRecord)
 
         self.assertEqual(rowIndex, i)
-        self.assertIsInstance(anomalyLikelihood, (float, int))
+        self.assertIsInstance(anomalyLikelihood, float)
 
 
       # Close the subprocess's stdin and wait for it to terminate


### PR DESCRIPTION
ENG-26 Switch (float, int) variant in testFeedInputGetOutput back to just checking for float since we're now using AnomalyLikelihood class that always returns a float.