### PR TITLE
UNI-169 We now need to support OS X build slaves

### DIFF
--- a/infrastructure/saltcellar/devtools/init.sls
+++ b/infrastructure/saltcellar/devtools/init.sls
@@ -20,7 +20,8 @@
 # ----------------------------------------------------------------------
 # Formula: devtools
 #
-# Install developer tools repository and updated developer tools
+{% if grains['os_family'] == 'RedHat' %}
+# Install developer tools repository and updated developer tools for CentOS
 
 # Install devtool repo - v2
 install-devtools-repo:
@@ -80,3 +81,5 @@ mysql-development-tools:
     - name: mysql-community-devel
     - require:
       - cmd: mysql-community-repository
+
+{% endif %}


### PR DESCRIPTION
Make sure the CentOS devtools don't get pulled in on non-CentOS machines

@jcasner @shantanoo please CR