### PR TITLE
Update to electron 0.33.0 which is based on node 4.1.0

### DIFF
--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -4,8 +4,8 @@
   "description": "Numenta Unicorn Cross-platform HTM Example Desktop Application",
   "main": "frontend/loader.js",
   "engines": {
-    "node": ">=0.12.7",
-    "npm": ">=2.11.3"
+    "node": ">=4.1.0",
+    "npm": ">=2.14.4"
   },
   "os": [
     "darwin",
@@ -85,7 +85,7 @@
     "babel-plugin-typecheck": "1.2.0",
     "casperjs": "1.1.0-beta3",
     "electron-debug": "0.2.0",
-    "electron-prebuilt": "0.31.2",
+    "electron-prebuilt": "0.33.0",
     "eslint": "1.3.1",
     "eslint-plugin-react": "3.3.1",
     "gulp": "3.9.0",
@@ -94,7 +94,7 @@
     "json-loader": "0.5.2",
     "mocha": "2.3.0",
     "mocha-casperjs": "0.5.4",
-    "node-inspector": "0.12.2",
+    "node-inspector": "0.12.3",
     "webpack": "1.12.1",
     "webpack-stream": "2.1.0"
   }


### PR DESCRIPTION
Last week `node` and `iojs` merged into `node 4` simplifying things for `node` developers. 
A few days later `electron` followed suit and replaced `iojs` with `node 4.1.0` simplifying things for `electron` developers.

Once this PR is merged you will need to upgrade node on your development machine and refresh `unicorn` dependencies with the following commands:

```shell
brew update
brew upgrade node
npm run clean
npm install
```

@unixorn Once this PR is merged we will need to install `node 4.1.0` on the build machine

CC: @brev @marionleborgne @jcasner 