### PR TITLE
Fixup result_quality_test to be consistent with cross-platform results

### DIFF
--- a/htmengine/requirements.txt
+++ b/htmengine/requirements.txt
@@ -4,6 +4,6 @@ sqlalchemy==0.9.4
 msgpack-python==0.3.0
 validictory==0.9.1
 mysql-python==1.2.5
-nupic==0.3.0
+nupic==0.3.2
 nta.utils>=0.0.0
 psutil==1.0.1

--- a/htmengine/tests/integration/result_quality_test.py
+++ b/htmengine/tests/integration/result_quality_test.py
@@ -139,10 +139,10 @@ class ResultQualityTests(test_case_base.TestCaseBase):
     dataIdentifier = "IIO"
     knownDataFile = "iio_us-east-1_i-a2eb1cd9_NetworkIn.csv"
     expectedResults = {"fn": 5,
-                       "fp": 4,
-                       "tn": 891,
+                       "fp": 5,
+                       "tn": 890,
                        "tp": 0,
-                       "quality": -250}
+                       "quality": -300}
 
     results1 = self._runQualityTest(dataIdentifier, knownDataFile,
                                     expectedResults)


### PR DESCRIPTION
This depends on an as of now, not yet completed 0.3.2 release of nupic in which the `nupic.bindings` dependency have been updated.

cc @scottpurdy 