### PR TITLE
UNI-169 Multi os support

### DIFF
--- a/infrastructure/saltcellar/motd/files/update-motd.centos
+++ b/infrastructure/saltcellar/motd/files/update-motd.centos
@@ -22,6 +22,6 @@
 
 # Use acta-diurna to update /etc/motd
 
-/usr/local/sbin/acta-diurna
+/usr/local/bin/acta-diurna
 # Add a blank line between motd and things printed by user login script
 echo >> /etc/motd

--- a/infrastructure/saltcellar/motd/init.sls
+++ b/infrastructure/saltcellar/motd/init.sls
@@ -22,9 +22,20 @@
 
 # Install tooling for automatic motd generation.
 
-# Install the motd driver package.
+# Install the motd driver script
 acta-diurna:
-  pkg.latest
+  file.managed:
+    - name: /usr/local/bin/acta-diurna
+    - source: https://raw.githubusercontent.com/unixorn/acta-diurna/master/acta-diurna.py
+    - source_hash: md5=747f4457e0de9ebb7b5791e3d71cb91f
+    - user: root
+    - group: wheel
+    - mode: 0755
+{% if grains['os_family'] == 'RedHat' %}
+    - require:
+      - file: python-27-symlink
+      - sls: numenta-python
+{% endif %}
 
 # motd fragment scripts go here
 /etc/update-motd.d:
@@ -84,15 +95,13 @@ update-motd:
     - group: wheel
     - mode: 0755
     - require:
-      - file: python-27-symlink
-      - pkg: acta-diurna
+      - file: acta-diurna
 # Run the update-motd job, but only when a fragment script is added or changed
   cmd.wait:
     - name: /usr/local/sbin/update-motd
     - cwd: /
     - require:
-      - pkg: acta-diurna
-      - sls: numenta-python
+      - file: acta-diurna
 
 {% if grains['os_family'] == 'RedHat' %}
 
@@ -107,7 +116,7 @@ motd-cronjob:
       - cron: set-sane-path-in-crontab
       - file: /etc/cron.daily/update-motd
       - file: /etc/update-motd.d
-      - pkg: acta-diurna
+      - file: acta-diurna
 
 update-motd-symlink:
   file.symlink:

--- a/infrastructure/saltcellar/motd/init.sls
+++ b/infrastructure/saltcellar/motd/init.sls
@@ -74,7 +74,7 @@ acta-diurna:
 update-motd:
 # Install our motd cronjob script
   file.managed:
-    - name: /etc/cron.daily/update-motd
+    - name: /usr/local/sbin/update-motd
     - source: salt://motd/files/update-motd.centos
     - mode: 0755
     - require:
@@ -82,12 +82,16 @@ update-motd:
       - pkg: acta-diurna
 # Run the update-motd job, but only run if a fragment script is added/changed
   cmd.wait:
-    - name: /etc/cron.daily/update-motd
+    - name: /usr/local/sbin/update-motd
     - cwd: /
     - require:
       - file: python-27-symlink
       - pkg: acta-diurna
       - sls: numenta-python
+
+{% if grains['os_family'] == 'RedHat' %}
+
+motd-cronjob:
 # Install the actual cronjob
   cron.present:
     - name: /etc/cron.daily/update-motd 2>&1 > /dev/null
@@ -102,5 +106,7 @@ update-motd:
 
 update-motd-symlink:
   file.symlink:
-    - target: /etc/cron.daily/update-motd
-    - name: /usr/local/sbin/update-motd
+    - name: /etc/cron.daily/update-motd
+    - target: /usr/local/sbin/update-motd
+
+{% endif %}

--- a/infrastructure/saltcellar/motd/init.sls
+++ b/infrastructure/saltcellar/motd/init.sls
@@ -30,13 +30,13 @@ acta-diurna:
 /etc/update-motd.d:
   file.directory:
     - user: root
-    - group: root
+    - group: wheel
     - mode: 0755
 
 /etc/update-motd.d.disabled:
   file.directory:
     - user: root
-    - group: root
+    - group: wheel
     - mode: 0755
 
 # Add Numenta logo to motd
@@ -44,7 +44,7 @@ acta-diurna:
   file.managed:
     - source: salt://motd/files/motd.logo
     - user: root
-    - group: root
+    - group: wheel
     - mode: 0644
     - require:
       - file: /etc/update-motd.d
@@ -55,6 +55,8 @@ acta-diurna:
 /etc/update-motd.d/20-banner.motd:
   file.managed:
     - source: salt://motd/files/20-banner.motd
+    - user: root
+    - group: wheel
     - mode: 0755
     - require:
       - file: /etc/update-motd.d
@@ -65,6 +67,8 @@ acta-diurna:
 /etc/update-motd.d/30-salt-version.motd:
   file.managed:
     - source: salt://motd/files/30-salt-version.motd
+    - user: root
+    - group: wheel
     - mode: 0755
     - require:
       - file: /etc/update-motd.d
@@ -76,16 +80,17 @@ update-motd:
   file.managed:
     - name: /usr/local/sbin/update-motd
     - source: salt://motd/files/update-motd.centos
+    - user: root
+    - group: wheel
     - mode: 0755
     - require:
       - file: python-27-symlink
       - pkg: acta-diurna
-# Run the update-motd job, but only run if a fragment script is added/changed
+# Run the update-motd job, but only when a fragment script is added or changed
   cmd.wait:
     - name: /usr/local/sbin/update-motd
     - cwd: /
     - require:
-      - file: python-27-symlink
       - pkg: acta-diurna
       - sls: numenta-python
 


### PR DESCRIPTION
Make motd formula work on both CentOS and OSX
* Set group ownership from root (CentOS only) to wheel, which exists on both platforms
* Get acta-diurna directly from GH instead of via an RPM

@lscheinkman, @shantanoo, @jcasner please CR
