### PR TITLE
ENG-67 Fix race condition that stalls tweet collector

### DIFF
--- a/taurus.metric_collectors/taurus/metric_collectors/collectorsdb/__init__.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/collectorsdb/__init__.py
@@ -19,9 +19,11 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
+import multiprocessing
 import optparse
 import random
 import os
+import threading
 
 
 import sqlalchemy
@@ -84,21 +86,29 @@ def getDSN():
 class _EngineSingleton(object):
 
 
-  _engine = None
+  _mpMutex = multiprocessing.Lock()
   _pid = None
+  _threadMutex = None
+  _engine = None
 
 
   @classmethod
   def getEngine(cls):
     pid = os.getpid()
 
-    if cls._pid != pid:
-      if cls._engine is not None:
-        cls._engine.dispose()
-        cls._engine = None
+    with cls._mpMutex:
+      if cls._pid is None:
+        cls._pid = pid
+        cls._threadMutex = threading.Lock()
+      else:
+        # NOTE: we've experienced race condition hangs when the non-empty
+        # _EngineSingleton was cloned via multiprocessing forking.
+        # `cls._engine.dispose()` didn't alleviate this problem
+        assert cls._pid == pid, "collectorsdb engine factory is not fork-safe"
 
-      cls._engine = sqlalchemy.create_engine(getDSN())
-      cls._pid = pid
+      with cls._threadMutex:
+        if cls._engine is None:
+          cls._engine = sqlalchemy.create_engine(getDSN())
 
     return cls._engine
 
@@ -107,8 +117,10 @@ class _EngineSingleton(object):
   def reset(cls):
     """ Reset internal engine and pid references
     """
-    cls._engine = None
-    cls._pid = None
+    with cls._mpMutex:
+      cls._pid = None
+      cls._threadMutex = None
+      cls._engine = None
 
 
 

--- a/taurus.metric_collectors/taurus/metric_collectors/collectorsdb/__init__.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/collectorsdb/__init__.py
@@ -156,13 +156,13 @@ def resetCollectorsdbMain():
   parser = optparse.OptionParser(helpString)
 
   parser.add_option(
-      "--suppress-prompt-and-obliterate-database",
-      action="store_true",
-      default=False,
-      dest="suppressPrompt",
-      help=("Suppresses confirmation prompt and proceedes with this "
-            "DESTRUCTIVE operation. This option is intended for scripting. "
-            "[default: %default]"))
+    "--suppress-prompt-and-obliterate-database",
+    action="store_true",
+    default=False,
+    dest="suppressPrompt",
+    help=("Suppresses confirmation prompt and proceedes with this "
+          "DESTRUCTIVE operation. This option is intended for scripting. "
+          "[default: %default]"))
 
   options, remainingArgs = parser.parse_args()
   if remainingArgs:

--- a/taurus.metric_collectors/taurus/metric_collectors/twitterdirect/twitter_direct_agent.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/twitterdirect/twitter_direct_agent.py
@@ -258,8 +258,8 @@ def buildTaggingMapAndStreamFilterParams(metricSpecs, authHandler):
 
   # Generate stream filter parameters
   streamFilterParams = dict(
-    track=[("@" + screen) for screen in screenNameToMetricsMap] +
-      [("$" + ticker) for ticker in symbolToMetricMap],
+    track=([("@" + screen) for screen in screenNameToMetricsMap] +
+           [("$" + ticker) for ticker in symbolToMetricMap]),
     follow=userIdToMetricsMap.keys(),
     stall_warnings=True
   )
@@ -472,28 +472,32 @@ class TweetStorer(object):
 
   class _CurrentStreamStats(_StreamingStatsBase):
     def __init__(self):
-      super(TweetStorer._CurrentStreamStats, self).__init__()
+      super(TweetStorer._CurrentStreamStats,  # pylint: disable=W0212
+            self).__init__()
 
       # Starting datetime of the current stream
       self.startingDatetime = None
 
     def __str__(self):
       return "%s; started=%s" % (
-        super(TweetStorer._CurrentStreamStats, self).__str__(),
+        super(TweetStorer._CurrentStreamStats,  # pylint: disable=W0212
+              self).__str__(),
         (self.startingDatetime.replace(microsecond=0).isoformat()
          if self.startingDatetime else None),)
 
 
   class _RuntimeStreamingStats(_StreamingStatsBase):
     def __init__(self):
-      super(TweetStorer._RuntimeStreamingStats, self).__init__()
+      super(TweetStorer._RuntimeStreamingStats,  # pylint: disable=W0212
+            self).__init__()
 
       # 1-based number of the current stream
       self.streamNumber = None
 
     def __str__(self):
       return "%s; streamNumber=%s" % (
-        super(TweetStorer._RuntimeStreamingStats, self).__str__(),
+        super(TweetStorer._RuntimeStreamingStats,  # pylint: disable=W0212
+              self).__str__(),
         self.streamNumber,)
 
 
@@ -537,7 +541,7 @@ class TweetStorer(object):
                       aggSec=aggSec,
                       msgQ=msgQ,
                       echoData=echoData)
-    tweetStorer._run()
+    tweetStorer._run()  # pylint: disable=W0212
 
 
   def _run(self):
@@ -571,28 +575,25 @@ class TweetStorer(object):
       tweets = deletes = None
       try:
         tweets, deletes = self._reapMessages(messages)
-      except Exception:
+      except Exception:  # pylint: disable=W0703
         g_log.exception("_reapMessages failed")
-        pass
 
       # Save (re)tweets
       if tweets:
         try:
           self._saveTweets(messages=tweets, aggRefDatetime=aggRefDatetime)
-        except Exception:
+        except Exception:  # pylint: disable=W0703
           g_log.exception("Failed to save numTweets=%d", len(tweets))
-          pass
 
       # Save deletion requests
       if deletes:
         try:
           self._saveTweetDeletionRequests(messages=deletes)
-        except Exception:
+        except Exception:  # pylint: disable=W0703
           g_log.exception("Failed to save deletion numRequests=%d",
                           len(deletes))
           for msg in deletes:
             g_log.error("Failed to save deletion msg=%s", msg)
-          pass
 
       # Echo messages to stdout if requested
       if self._echoData:
@@ -875,7 +876,7 @@ class TweetStorer(object):
       try:
         tweet, references = self._createTweetAndReferenceRows(msg,
                                                               aggRefDatetime)
-      except Exception:
+      except Exception:  # pylint: disable=W0703
         g_log.exception("Failed to reap tweet=%s", msg)
       else:
         tweetRows.append(tweet)
@@ -968,7 +969,7 @@ class TweetForwarder(object):
     :param int aggSec: metric aggregation period in seconds
     """
     g_log.info("%s thread is running", cls.__name__)
-    cls()._run()
+    cls()._run()  # pylint: disable=W0212
 
 
   def _run(self):
@@ -1175,7 +1176,7 @@ class MetricDataForwarder(object):
     :param int aggSec: metric aggregation period in seconds
     """
     g_log.info("%s thread is running", cls.__name__)
-    cls(metricSpecs, aggSec)._run()
+    cls(metricSpecs, aggSec)._run()  # pylint: disable=W0212
 
 
   def _run(self):
@@ -1307,7 +1308,7 @@ class MetricDataForwarder(object):
         self.aggregateAndForward(
           aggStartDatetime=aggStartDatetime,
           stopDatetime=aggStartDatetime + periodTimedelta)
-      except Exception:
+      except Exception:  # pylint: disable=W0703
         return lastEmittedAggTime
 
       # Update db with last successfully-emitted datetime
@@ -1616,7 +1617,6 @@ def main():
   except KeyboardInterrupt:
     # Log with exception info to help debug deadlocks
     g_log.info("Observed KeyboardInterrupt", exc_info=True)
-    pass
   except:
     g_log.exception("Failed")
     raise

--- a/taurus.metric_collectors/tests/integration/collectorsdb_test.py
+++ b/taurus.metric_collectors/tests/integration/collectorsdb_test.py
@@ -36,15 +36,6 @@ def setUpModule():
   logging_support.LoggingSupport.initTestApp()
 
 
-
-def _forkedEngineId():
-  """ Get engine and return id.  Needs to be in global namespace for
-  multiprocessing.Pool().apply() to work properly
-  """
-  return id(collectorsdb.engineFactory())
-
-
-
 def startProxy(host, port, listenPort):
   """ Start a proxy using netcat (nc)
 
@@ -110,11 +101,10 @@ class CollectorsdbTestCase(unittest.TestCase):
     engine2 = collectorsdb.engineFactory()
     self.assertIs(engine2, engine)
 
-    # Call collectorsdb.engineFactory() in different process, assert new
-    # instance
-    originalEngineId = id(engine)
-    engine3 = multiprocessing.Pool(processes=1).apply(_forkedEngineId)
-    self.assertNotEqual(id(engine3), originalEngineId)
+    # Call collectorsdb.engineFactory() in different process, assert raises
+    # AssertionError
+    with self.assertRaises(AssertionError):
+      multiprocessing.Pool(processes=1).apply(collectorsdb.engineFactory)
 
 
 

--- a/taurus.metric_collectors/tests/unit/collectorsdb_test.py
+++ b/taurus.metric_collectors/tests/unit/collectorsdb_test.py
@@ -46,8 +46,7 @@ class CollectorsdbTestCase(unittest.TestCase):
 
     # Explicitly spec out sqlalchemy.create_engine()
     firstCall = Mock(spec_set=sqlalchemy.engine.base.Engine)
-    secondCall = Mock(spec_set=sqlalchemy.engine.base.Engine)
-    sqlalchemyMock.create_engine.side_effect = iter([firstCall, secondCall])
+    sqlalchemyMock.create_engine.side_effect = [firstCall]
 
     # Call collectorsdb.engineFactory()
     engine = collectorsdb.engineFactory()
@@ -58,14 +57,13 @@ class CollectorsdbTestCase(unittest.TestCase):
     self.assertIs(engine2, firstCall)
     self.assertEqual(sqlalchemyMock.create_engine.call_count, 1)
 
-    # Call collectorsdb.engineFactory() in different process, assert new
-    # instance
-    with patch("taurus.metric_collectors.collectorsdb.os",
+    # Call collectorsdb.engineFactory() in different process, assert raises
+    # assertion error
+    with patch("taurus.metric_collectors.collectorsdb.os.getpid",
+               return_value=collectorsdb._EngineSingleton._pid + 1,
                autospec=True) as osMock:
-      osMock.getpid.return_value = collectorsdb._EngineSingleton._pid + 1
-      engine3 = collectorsdb.engineFactory()
-      self.assertTrue(engine.dispose.called)
-      self.assertIs(engine3, secondCall)
+      with self.assertRaises(AssertionError):
+        engine3 = collectorsdb.engineFactory()
 
 
 

--- a/taurus.metric_collectors/tests/unit/collectorsdb_test.py
+++ b/taurus.metric_collectors/tests/unit/collectorsdb_test.py
@@ -22,16 +22,11 @@
 
 import unittest2 as unittest
 
-from mock import DEFAULT, Mock, patch
-import MySQLdb
+from mock import Mock, patch
 import sqlalchemy
-from sqlalchemy.engine import Engine
 import sqlalchemy.exc
 
-from nta.utils.sqlalchemy_utils import _ALL_RETRIABLE_ERROR_CODES
-
 from taurus.metric_collectors import collectorsdb, logging_support
-from taurus.metric_collectors.collectorsdb import retryOnTransientErrors
 
 
 
@@ -61,9 +56,9 @@ class CollectorsdbTestCase(unittest.TestCase):
     # assertion error
     with patch("taurus.metric_collectors.collectorsdb.os.getpid",
                return_value=collectorsdb._EngineSingleton._pid + 1,
-               autospec=True) as osMock:
+               autospec=True):
       with self.assertRaises(AssertionError):
-        engine3 = collectorsdb.engineFactory()
+        collectorsdb.engineFactory()
 
 
 


### PR DESCRIPTION
ENG-67 We've experienced race condition hangs when the non-empty _EngineSingleton was cloned via multiprocessing forking. `cls._engine.dispose()` didn't alleviate this problem. The fix is
to fork the worker processes before anything in the main process invokes collectorsdb.engineFactory().

ENG-67 Fix unit tests to expect AssertionError when pid doesn't match the current pid.

ENG-67 In testEngineFactorySingletonPattern: expect AssertionError from collectorsdb.engineFactory() after populating the singleton in current process and requesting the engine again from a forked process