### PR TITLE
TAUR-1301 Change the ownership for /opt/numenta/anaconda

### DIFF
--- a/infrastructure/saltcellar/numenta-python/init.sls
+++ b/infrastructure/saltcellar/numenta-python/init.sls
@@ -92,7 +92,7 @@ python-27-symlink:
 # directory tree has the correct ownership.
 enforce-anaconda-permissions:
   cmd.wait:
-    - name: chown -R ec2-user:ec2-user /opt/numenta/anaconda
+    - name: chown -R (test -f /etc/numenta/anaconda-owner && cat /etc/numenta/anaconda-owner || echo ec2-user:ec2-user) /opt/numenta/anaconda
     - require:
       - group: ec2-user
       - pkg: anaconda-python


### PR DESCRIPTION
Change ownership of /opt/numenta/anaconda according to the setting in /etc/numenta/anaconda-owner. If file doesn't exist, use ec2-user:ec2-user.


Cc: @jcasner, @unixorn 