### PR TITLE
ENG-62 Implement an additional taurus metric collectors deployment resource accessibility test

### DIFF
--- a/nta.utils/nta/utils/error_reporting.py
+++ b/nta.utils/nta/utils/error_reporting.py
@@ -38,8 +38,8 @@ g_log = logging.getLogger(__name__)
 
 def sendMonitorErrorEmail(monitorName, resourceName, message, isTest=False,
                           subjectPrefix=None, params=None):
-  """
-  Sends an email concerning a monitor related error.
+  """Sends an email concerning a monitor related error. Expects additional
+  paramteres via environment variables as documented in ``sendErrorEmail``.
   :param monitorName: Name of monitor detecting error
   :type monitorName: string
   :param resourceName: URL checked by this monitor
@@ -48,7 +48,8 @@ def sendMonitorErrorEmail(monitorName, resourceName, message, isTest=False,
   :type message: string
   :param isTest: flag signaling whether email is being sent as a test
   :type isTest: Boolean
-  :param params: an optional dict that must contain the following keys:
+  :param params: an optional dict to use instead of environment variables that
+    must contain the following keys:
                  senderAddress,
                  recipients,
                  awsRegion,
@@ -106,7 +107,8 @@ def sendErrorEmail(subject, body, params=None):
   :type subject: string
   :param body: Email body
   :type body: string
-  :param params: an optional dict that must contain the following keys:
+  :param params: an optional dict to use instead of environment variables that
+    must contain the following keys:
                  senderAddress,
                  recipients,
                  awsRegion,

--- a/taurus.metric_collectors/tests/deployment/resource_accessibility_test.py
+++ b/taurus.metric_collectors/tests/deployment/resource_accessibility_test.py
@@ -36,6 +36,7 @@ import unittest
 import tweepy
 
 from nta.utils import error_handling
+from nta.utils import error_reporting
 from nta.utils.message_bus_connector import MessageBusConnector
 
 from taurus.metric_collectors import collectorsdb
@@ -135,6 +136,17 @@ class TaurusMetricCollectorsResourceAccessibilityTestCase(unittest.TestCase):
       fields=["Outcome"])
 
     self.assertEqual(data["Outcome"], "Success")
+
+
+  @_RETRY_SERVICE_RUNNING_CHECK
+  def testSendErrorEmailIsPossible(self):
+    """Send email to devnull@numenta.com via error-reporting email mechanism"""
+    params = error_reporting._getErrorReportingParamsFromEnv()
+    params["recipients"][:] = ["devnull@numenta.com"]
+
+    error_reporting.sendErrorEmail(subject="testSendErrorEmailIsPossible",
+                                   body="Testing testSendErrorEmailIsPossible",
+                                   params=params)
 
 
 


### PR DESCRIPTION
ENG-62 Implement an additional taurus metric collectors deployment resource accessibility test that validates the account's authorization to send emails (used for error-reporting) via the collector's SES configuration.

NOTE: This bit us during the initial deployment of the integrated stock symbol and twitter handle services.