### PR TITLE
Hotfix anaconda permission change issue

### DIFF
--- a/infrastructure/saltcellar/numenta-python/files/correct-anaconda-ownership
+++ b/infrastructure/saltcellar/numenta-python/files/correct-anaconda-ownership
@@ -1,0 +1,43 @@
+#!/bin/bash
+# ----------------------------------------------------------------------
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+
+# Set the permissions & ownership for anaconda
+#
+# Some roles (like the jenkins infrastructure) need write permission in
+# /opt/numenta/anaconda for users other than ec2-user.
+
+ANACONDA_D="/opt/numenta/anaconda"
+ANACONDA_OWNER_F="/etc/numenta/anaconda-owner"
+
+# Check to see what user should own the anaconda tree
+if [ -f "${ANACONDA_OWNER_F}" ]; then
+  ANACONDA_OWNER=$(cat "${ANACONDA_OWNER_F}")
+else
+  ANACONDA_OWNER="ec2-user:engineering"
+fi
+
+# Fixup the permissions in the anaconda tree
+chown -R "${ANACONDA_OWNER}" "${ANACONDA_D}"
+
+# Grant write permission to group on directories
+find "${ANACONDA_D}" -type d -exec chmod g+rwx '{}' ';'
+
+# And files
+find "${ANACONDA_D}" -type f -exec chmod g+rw '{}' ';'

--- a/infrastructure/saltcellar/numenta-python/init.sls
+++ b/infrastructure/saltcellar/numenta-python/init.sls
@@ -85,15 +85,23 @@ python-27-symlink:
     - target: /opt/numenta/anaconda/bin/python
     - name: /usr/local/bin/python2.7
     - require:
-      - cmd: enforce-anaconda-permissions
       - pkg: anaconda-python
+
+correct-anaconda-ownership-tool:
+  file.managed:
+    - name: /usr/local/sbin/correct-anaconda-ownership
+    - source: salt://numenta-python/files/correct-anaconda-ownership
+    - user: root
+    - group: wheel
+    - mode: 0755
 
 # Once we have installed our packages, make sure that the anaconda python
 # directory tree has the correct ownership.
 enforce-anaconda-permissions:
   cmd.wait:
-    - name: chown -R (test -f /etc/numenta/anaconda-owner && cat /etc/numenta/anaconda-owner || echo ec2-user:ec2-user) /opt/numenta/anaconda
+    - name: /usr/local/sbin/correct-anaconda-ownership
     - require:
+      - file: correct-anaconda-ownership-tool
       - group: ec2-user
       - pkg: anaconda-python
       - user: ec2-user


### PR DESCRIPTION
The old cmd.run didn't work, probably because of the `&&` and `||` entries in the name clause

Using a tool script also allows us to call this in more from our other
infrastructure salt formulas

cc: @shantanoo @jcasner