### PR TITLE
fixes  #231: Confusing docstring in `deleteMetric()

### DIFF
--- a/taurus.metric_collectors/taurus/metric_collectors/metric_utils.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/metric_utils.py
@@ -319,7 +319,7 @@ def deleteMetric(host, apiKey, metricName):
 
   :param host: API server's hostname or IP address
   :param apiKey: API server's API Key
-  :param modelId: id of the metric to be deleted
+  :param modelName: name of the metric to be deleted
 
   :raises: RetriesExceededError
   :raises: MetricDeleteRequestError


### PR DESCRIPTION
@oxtopus 
fixes  #231: Confusing docstring in `deleteMetric(). 

changed line322 from modelId to "modelName: name of the metric to be deleted"