### PR TITLE
fixes #231: 

### DIFF
--- a/taurus.metric_collectors/taurus/metric_collectors/metric_utils.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/metric_utils.py
@@ -319,7 +319,7 @@ def deleteMetric(host, apiKey, metricName):
 
   :param host: API server's hostname or IP address
   :param apiKey: API server's API Key
-  :param modelId: id of the metric to be deleted
+  :param modelName: name of the metric to be deleted
 
   :raises: RetriesExceededError
   :raises: MetricDeleteRequestError

--- a/taurus.metric_collectors/taurus/metric_collectors/metric_utils.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/metric_utils.py
@@ -319,7 +319,7 @@ def deleteMetric(host, apiKey, metricName):
 
   :param host: API server's hostname or IP address
   :param apiKey: API server's API Key
-  :param modelName: name of the metric to be deleted
+  :param metricName: name of the metric to be deleted
 
   :raises: RetriesExceededError
   :raises: MetricDeleteRequestError


### PR DESCRIPTION
@oxtopus
Confusing docstring in `deleteMetric()` #231 
changed docstring at line 322 to ":param metricName: name of the metric to be deleted",