### PR TITLE
Install using revised python prefix as opposed to split package install location and script dir

### DIFF
--- a/htm.it/README.rst
+++ b/htm.it/README.rst
@@ -26,11 +26,9 @@ automatically with htm-it.
 
 ::
 
-    ./install-htm-it.sh <site-packages in $PYTHONPATH> <somewhere in $PATH>
+    ./install-htm-it.sh <PREFIX>
 
-The first directory can be any directory on your `PYTHONPATH`. The second directory can be any directory on your `PATH`.
-
-- e.g., `./install-htm-it.sh /opt/numenta/anaconda/lib/python2.7/site-packages/ /opt/numenta/anaconda/bin/`
+- e.g., `./install-htm-it.sh /opt/numenta/anaconda`
 
 
 Config

--- a/htm.it/htm/it/pipeline/README.md
+++ b/htm.it/htm/it/pipeline/README.md
@@ -3,7 +3,7 @@ The pipeline can be run end-to-end via the driver script, or each individual ste
 
 #### Prerequisites
 - Ensure the products repository dir is exported in PRODUCTS variable
-- Run `$PRODUCTS/install-htm-it.sh <INSTALL_DIR> <SCRIPT_DIR>` where `<INSTALL_DIR>` is a valid folder on your `PYTHONPATH` and `<SCRIPT_DIR>` is a valid folder on your `PATH`
+- Run `$PRODUCTS/install-htm-it.sh <PREFIX>` where `<PREFIX>` conforms to the Python prefix scheme described at https://docs.python.org/2/install/#how-installation-works
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables must be set
 - Set `HTM_IT_HOME` to `$PRODUCTS/htm-it` to use your existing checkout
 - When running locally, make to sure to set "BUILD_WORKSPACE" to one level above your

--- a/infrastructure/ami-tools/packer-scripts/configure-htm-it-pipeline-centos6.5-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-htm-it-pipeline-centos6.5-ami
@@ -147,7 +147,7 @@ install-htm-it() {
   pushd "${PRODUCTS}"
     echo "Running install-htm-it.sh"
 
-    ./install-htm-it.sh "${NUMENTA}/anaconda/lib/python2.7/site-packages" "${NUMENTA}/anaconda/bin"
+    ./install-htm-it.sh "${NUMENTA}/anaconda"
     if [ $? != 0 ]; then
       echo "Failed to install HTM-IT"
       exit 1

--- a/infrastructure/ami-tools/packer-scripts/configure-htm-it-pipeline-centos7-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-htm-it-pipeline-centos7-ami
@@ -86,7 +86,7 @@ configure-private-settings() {
   splat
 
   echo "Write private settings from env vars to private-settings.sh file"
-  
+
   if [ -f /etc/htm.it/private-settings.sh ]; then
     sudo rm -f /etc/htm.it/private-settings.sh
   fi
@@ -180,7 +180,7 @@ install-htm-it() {
   sudo ln -s "${BOOTSCRIPTS_D}/prehtm-it.html" /usr/share/nginx/html/
 
   cd "${PRODUCTS}"
-  ./install-htm-it.sh "${NUMENTA}/lib/python2.7/site-packages" "${NUMENTA}/bin"
+  ./install-htm-it.sh "${NUMENTA}"
 }
 
 bootstrap-htm-it() {

--- a/install-htm-it-from-bare-centos7.sh
+++ b/install-htm-it-from-bare-centos7.sh
@@ -27,7 +27,7 @@
 #
 # ----------------------------------------------------------------------
 # This is a convenience script to install HTM-IT onto a bare Centos 7 machine.
-# 
+#
 # It was tested against a Centos 7 instance in AWS on 9 July 2015:
 #   AWS Marketplace: https://aws.amazon.com/marketplace/pp/B00O7WM7QW
 #   AMI ID: ami-c7d092f7 in us-west-2
@@ -70,7 +70,7 @@ cd /opt/numenta/numenta-apps/
 pip install paver==1.2.4 --user
 pip install uwsgi==2.0.4 --user
 pip install agamotto==0.5.1 --user
-./install-htm-it.sh /home/centos/.local/lib/python2.7/site-packages /home/centos/.local/bin
+./install-htm-it.sh /home/centos/.local
 
 # Start MySQL and Rabbit
 sudo service mysqld start

--- a/install-htm-it.sh
+++ b/install-htm-it.sh
@@ -24,11 +24,11 @@ set -o errexit
 
 function install {
   pushd $1
-  python setup.py develop --install-dir=$2 --script-dir=$3
+  python setup.py develop --prefix=$2
   popd
 }
 
-install nta.utils $1 $2
-install htmengine $1 $2
-install infrastructure $1 $2
-install htm.it $1 $2
+install nta.utils $1
+install htmengine $1
+install infrastructure $1
+install htm.it $1

--- a/install-infrastructure.sh
+++ b/install-infrastructure.sh
@@ -24,8 +24,8 @@ set -o errexit
 
 function install {
   pushd $1
-  python setup.py develop --install-dir=$2 --script-dir=$3
+  python setup.py develop --prefix=$2
   popd
 }
 
-install infrastructure $1 $2
+install infrastructure $1

--- a/install-taurus-metric-collectors.sh
+++ b/install-taurus-metric-collectors.sh
@@ -22,21 +22,18 @@
 
 # Install taurus.metric_collectors and its dependencies
 # ARGS:
-# First position arg: installation directory;
-#   e.g., Linux: /opt/numenta/anaconda/lib/python2.7/site-packages/
-#   e.g., Mac OS X: ~/Library/Python/2.7/lib/python/site-packages/
-# Second positional arg: script directory; e.g., /opt/numenta/anaconda/bin/
-#   e.g., Linux: /opt/numenta/anaconda/bin/
-#   e.g., Mac OS X: ~/Library/Python/2.7/bin/ 
+# First position arg: installation prefix;
+#   e.g., Linux: /opt/numenta/anaconda
+#   e.g., Mac OS X: ~/Library/Python/2.7
 
 set -o errexit
 
 function install {
   pushd $1
-  python setup.py develop --install-dir=$2 --script-dir=$3
+  python setup.py develop --prefix=$2
   popd
 }
 
-install nta.utils $1 $2
-install infrastructure $1 $2
-install taurus.metric_collectors $1 $2
+install nta.utils $1
+install infrastructure $1
+install taurus.metric_collectors $1

--- a/install-taurus-monitoring
+++ b/install-taurus-monitoring
@@ -24,10 +24,10 @@ set -o errexit
 
 function install {
   pushd $1
-    python setup.py develop --install-dir=$2 --script-dir=$3
+    python setup.py develop --prefix=$2
   popd
 }
 
-install nta.utils $1 $2
-install infrastructure $1 $2
-install taurus.monitoring $1 $2
+install nta.utils $1
+install infrastructure $1
+install taurus.monitoring $1

--- a/install-taurus.sh
+++ b/install-taurus.sh
@@ -24,12 +24,12 @@ set -o errexit
 
 function install {
   pushd $1
-  python setup.py develop --install-dir=$2 --script-dir=$3
+  python setup.py develop --prefix=$2
   popd
 }
 
-install nta.utils $1 $2
-install htmengine $1 $2
-install infrastructure $1 $2
-./install-taurus-metric-collectors.sh $1 $2
-install taurus $1 $2
+install nta.utils $1
+install htmengine $1
+install infrastructure $1
+./install-taurus-metric-collectors.sh $1
+install taurus $1

--- a/taurus/README.md
+++ b/taurus/README.md
@@ -24,7 +24,7 @@ First, install `nta.utils`, `htmengine` and `taurus.metric_collectors`.  Then, t
 `install-taurus.sh` is included at the root of the `numenta-apps` repository as a
 convenient alternative:
 
-    ./install-taurus.sh <site-packages in $PYTHONPATH> <somewhere in $PATH>
+    ./install-taurus.sh <PREFIX>
 
 The configuration files for production reside in `conf/`.  It is recommended
 that you copy and rename this directory so that you may make the required

--- a/taurus/pipeline/scripts/initialize-remote-taurus-servers.sh
+++ b/taurus/pipeline/scripts/initialize-remote-taurus-servers.sh
@@ -307,8 +307,7 @@ pushd "${REPOPATH}"
     "cd /opt/numenta/products &&
      ./taurus/pipeline/scripts/uninstall_nupic.py &&
      ./install-taurus.sh \
-        /opt/numenta/anaconda/lib/python2.7/site-packages \
-        /opt/numenta/anaconda/bin &&
+        /opt/numenta/anaconda &&
      taurus-set-rabbitmq \
         --host=${RABBITMQ_HOST} \
         --user=${RABBITMQ_USER} \
@@ -356,8 +355,7 @@ pushd "${REPOPATH}"
   ssh -v -t ${SSH_ARGS} "${TAURUS_COLLECTOR_USER}"@"${TAURUS_COLLECTOR_HOST}" \
     "cd /opt/numenta/products &&
      ./install-taurus-metric-collectors.sh \
-        /opt/numenta/anaconda/lib/python2.7/site-packages \
-        /opt/numenta/anaconda/bin &&
+        /opt/numenta/anaconda &&
      taurus-set-collectorsdb-login \
         --host=${MYSQL_HOST} \
         --user=${MYSQL_USER} \

--- a/taurus/pipeline/scripts/refresh-remote-taurus-servers.sh
+++ b/taurus/pipeline/scripts/refresh-remote-taurus-servers.sh
@@ -325,8 +325,7 @@ pushd "${REPOPATH}"
     "cd /opt/numenta/products &&
      ./taurus/pipeline/scripts/uninstall_nupic.py &&
      ./install-taurus.sh \
-        /opt/numenta/anaconda/lib/python2.7/site-packages \
-        /opt/numenta/anaconda/bin &&
+        /opt/numenta/anaconda &&
      taurus-set-rabbitmq \
         --host=${RABBITMQ_HOST} \
         --user=${RABBITMQ_USER} \
@@ -372,8 +371,7 @@ pushd "${REPOPATH}"
   ssh -v -t ${SSH_ARGS} "${TAURUS_COLLECTOR_USER}"@"${TAURUS_COLLECTOR_HOST}" \
     "cd /opt/numenta/products &&
      ./install-taurus-metric-collectors.sh \
-        /opt/numenta/anaconda/lib/python2.7/site-packages \
-        /opt/numenta/anaconda/bin &&
+        /opt/numenta/anaconda &&
      taurus-set-collectorsdb-login \
         --host=${MYSQL_HOST} \
         --user=${MYSQL_USER} \

--- a/taurus/pipeline/scripts/update-remote-taurus-servers.sh
+++ b/taurus/pipeline/scripts/update-remote-taurus-servers.sh
@@ -331,8 +331,7 @@ pushd "${REPOPATH}"
     "cd /opt/numenta/products &&
      ./taurus/pipeline/scripts/uninstall_nupic.py &&
      ./install-taurus.sh \
-        /opt/numenta/anaconda/lib/python2.7/site-packages \
-        /opt/numenta/anaconda/bin &&
+        /opt/numenta/anaconda &&
      taurus-set-rabbitmq \
         --host=${RABBITMQ_HOST} \
         --user=${RABBITMQ_USER} \
@@ -374,8 +373,7 @@ pushd "${REPOPATH}"
   ssh -v -t ${SSH_ARGS} "${TAURUS_COLLECTOR_USER}"@"${TAURUS_COLLECTOR_HOST}" \
     "cd /opt/numenta/products &&
      ./install-taurus-metric-collectors.sh \
-        /opt/numenta/anaconda/lib/python2.7/site-packages \
-        /opt/numenta/anaconda/bin &&
+        /opt/numenta/anaconda &&
      taurus-set-collectorsdb-login \
         --host=${MYSQL_HOST} \
         --user=${MYSQL_USER} \


### PR DESCRIPTION
It's just simpler to have to specify a single prefix rather than two paths.  In practice, the two paths always share a common prefix anyway.

Requires `install-prefix` companion branch in internal infrastructure repository.