### PR TITLE
Removed E1101 and E1103 from the disable list in pylintrc, because th…

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -62,11 +62,6 @@ load-plugins=
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
 #
-# TODO: Remove this check if possible.
-# E1101 - Enforces that all class attribute references are defined in the class
-#     which is not true for classes that have dynamic attributes.
-# E1103 - Checks that object types has accessed member attribute or method.
-#     Sometimes fails to correctly infer the type of an object.
 # W0142 - Using * or ** magic.
 # W0105 - String statement has no effect. Disabled to allow for doc strings.
 # W0231 - __init__ method from base class is not called.
@@ -78,7 +73,7 @@ load-plugins=
 # R0904 - Too many public methods.
 # R0911 - Too many return statements
 # R0912 - Too many branches
-disable=E1101,E1103,W0142,W0105,W0231,W0621,C0111,C0302,C0322,R0902,R0904,R0911,R0912
+disable=W0142,W0105,W0231,W0621,C0111,C0302,C0322,R0902,R0904,R0911,R0912
 
 
 [REPORTS]
@@ -86,9 +81,6 @@ disable=E1101,E1103,W0142,W0105,W0231,W0621,C0111,C0302,C0322,R0902,R0904,R0911,
 # Set the output format. Available formats are text, parseable, colorized, msvs
 # (visual studio) and html
 output-format=text
-
-# Include message's id in output
-include-ids=yes
 
 # Put messages in a separate file for each module / package specified on the
 # command line instead of printing them on stdout. Reports (if any) will be


### PR DESCRIPTION
Removed E1101 and E1103 from the disable list in pylintrc, because this was hiding erroneous member accesses. It's understood that removing those error numbers will result in errors on dynamic members, and those will need to be disabled in code on a case-by-case basis.
Removed deprecated setting include-ids.