### PR TITLE
TAUR-1538 Update rabbitmq version & infrastructure module changes

### DIFF
--- a/infrastructure/requirements.txt
+++ b/infrastructure/requirements.txt
@@ -1,4 +1,4 @@
-boto>=2.38.0
-fabric>=1.9.0
+boto==2.38.0
+fabric==1.9.0
 grokcli
-PyYAML>=3.10
+PyYAML==3.11

--- a/infrastructure/requirements.txt
+++ b/infrastructure/requirements.txt
@@ -1,4 +1,4 @@
-boto==2.38.0
-fabric==1.9.0
+boto>=2.38.0
+fabric>=1.9.0
 grokcli
-PyYAML==3.10
+PyYAML>=3.10

--- a/infrastructure/saltcellar/rabbitmq/init.sls
+++ b/infrastructure/saltcellar/rabbitmq/init.sls
@@ -55,7 +55,7 @@ rabbitmq_repo:
 rabbitmq-server:
   pkg.installed:
     - name: rabbitmq-server
-    - version: 3.5.4-1
+    - version: 3.5.6-1
   service.running:
     - enable: true
     - require:

--- a/infrastructure/setup.py
+++ b/infrastructure/setup.py
@@ -5,6 +5,6 @@ requirements = map(str.strip, open("requirements.txt").readlines())
 setup(
     name = "infrastructure",
     packages = find_packages(),
-    version = "0.1.1",
+    version = "0.1.2",
     install_requires = requirements
 )


### PR DESCRIPTION
## Infrastructure:
Changed our requirements to be `>=`, not `==`. We had run into an issue where taurus specified an exact version of 3.11 for PyYAML and infrastructure was specifying exactly 3.10.

The infrastructure module needs to be less picky so that it won't conflict with our other modules.

## RabbitMQ
Deal with upstream update, 3.5.4 is no longer available.

TODO: [DEVOPS-31](https://jira.numenta.com/browse/DEVOPS-31) - Update the carbonite repo with all the rpms we're currently using so we don't have to upgrade packages just because upstream did.

@jcasner please CR