### PR TITLE
Fix a breakage caused by grok->htm-it rename.

### DIFF
--- a/infrastructure/infrastructure/utilities/numenta_rpm.py
+++ b/infrastructure/infrastructure/utilities/numenta_rpm.py
@@ -369,7 +369,7 @@ class NumentaRPM(object):
     actualSHA = self.installProductsIntoHTMITFakeroot()
 
     productsDirectory = self.productsDirectory
-    htm-itPath = os.path.join(productsDirectory, "htm-it")
+    htmItPath = os.path.join(productsDirectory, "htm-it")
     iteration = git.getCommitCount(productsDirectory, logger=logger)
 
     # Extend PYTHONPATH for setup.py, build & cleanup scripts
@@ -383,7 +383,7 @@ class NumentaRPM(object):
                             productsDirectory
 
     # Install wheels if any have been specified
-    with changeToWorkingDir(htm-itPath):
+    with changeToWorkingDir(htmItPath):
       for wheel in config.wheels:
         logger.info("Installing %s", os.path.basename(wheel))
         if not os.path.exists(wheel):

--- a/infrastructure/infrastructure/utilities/numenta_rpm.py
+++ b/infrastructure/infrastructure/utilities/numenta_rpm.py
@@ -369,7 +369,7 @@ class NumentaRPM(object):
     actualSHA = self.installProductsIntoHTMITFakeroot()
 
     productsDirectory = self.productsDirectory
-    htmItPath = os.path.join(productsDirectory, "htm-it")
+    htmItPath = os.path.join(productsDirectory, "htm.it")
     iteration = git.getCommitCount(productsDirectory, logger=logger)
 
     # Extend PYTHONPATH for setup.py, build & cleanup scripts

--- a/infrastructure/setup.py
+++ b/infrastructure/setup.py
@@ -5,6 +5,6 @@ requirements = map(str.strip, open("requirements.txt").readlines())
 setup(
     name = "infrastructure",
     packages = find_packages(),
-    version = "0.1.2",
+    version = "0.1.3",
     install_requires = requirements
 )


### PR DESCRIPTION
This was causing setup.py bdist upload to fail for the infrastructure module, which we need to do to resolve [TAUR-1538](https://jira.numenta.com/browse/TAUR-1538)
```
byte-compiling build/bdist.linux-x86_64/dumb/opt/numenta/anaconda/lib/python2.7/site-packages/infrastructure/utilities/numenta_rpm.py to numenta_rpm.pyc
  File "/opt/numenta/anaconda/lib/python2.7/site-packages/infrastructure/utilities/numenta_rpm.py", line 372
SyntaxError: can't assign to operator
```
@jcasner please CR