### PR TITLE
ENG-51 Replace use of nupic.support.decorators.retry with retry decorator from nta.utils

### DIFF
--- a/htm.it/htm/it/app/aws/asg_utils.py
+++ b/htm.it/htm/it/app/aws/asg_utils.py
@@ -26,7 +26,7 @@ import time
 
 import boto.ec2.autoscale
 from boto.exception import (AWSConnectionError, BotoServerError)
-from nupic.support import decorators
+from nta.utils.error_handling import retry
 
 from htm.it.app import config
 
@@ -107,13 +107,13 @@ def retryOnAutoScalingTransientError(logger=logging.root,
 
     return True
 
-  return decorators.retry(
+  return retry(
     timeoutSec=timeoutSec,
     initialRetryDelaySec=INITIAL_RETRY_BACKOFF_SEC,
     maxRetryDelaySec=MAX_RETRY_BACKOFF_SEC,
     retryExceptions=RETRY_EXCEPTIONS,
     retryFilter=retryFilter,
-    getLoggerCallback=lambda: logger,
+    logger=logger,
     clientLabel="retryOnAutoScalingTransientError")
 
 

--- a/htm.it/htm/it/app/aws/cloudwatch_utils.py
+++ b/htm.it/htm/it/app/aws/cloudwatch_utils.py
@@ -26,7 +26,7 @@ import logging
 
 from boto.exception import (AWSConnectionError, BotoServerError)
 
-from nupic.support import decorators
+from nta.utils.error_handling import retry
 
 from htmengine.utils import roundUpDatetime
 
@@ -118,13 +118,13 @@ def retryOnCloudWatchTransientError(logger=logging.root,
 
     return True
 
-  return decorators.retry(
+  return retry(
     timeoutSec=timeoutSec,
     initialRetryDelaySec=INITIAL_RETRY_BACKOFF_SEC,
     maxRetryDelaySec=MAX_RETRY_BACKOFF_SEC,
     retryExceptions=RETRY_EXCEPTIONS,
     retryFilter=retryFilter,
-    getLoggerCallback=lambda: logger,
+    logger=logger,
     clientLabel="retryOnCloudWatchTransientError")
 
 

--- a/htm.it/htm/it/app/aws/ec2_utils.py
+++ b/htm.it/htm/it/app/aws/ec2_utils.py
@@ -29,7 +29,7 @@ import time
 import boto
 import boto.ec2
 
-from nupic.support import decorators
+from nta.utils.error_handling import retry
 
 from htm.it.app import config
 import htm.it.app.exceptions
@@ -186,13 +186,13 @@ def retryOnEC2TransientError(logger=logging.root,
 
     return True
 
-  return decorators.retry(
+  return retry(
     timeoutSec=timeoutSec,
     initialRetryDelaySec=INITIAL_RETRY_BACKOFF_SEC,
     maxRetryDelaySec=MAX_RETRY_BACKOFF_SEC,
     retryExceptions=RETRY_EXCEPTIONS,
     retryFilter=retryFilter,
-    getLoggerCallback=lambda: logger,
+    logger=logger,
     clientLabel="retryOnEC2TransientError")
 
 

--- a/htm.it/htm/it/app/aws/elb_utils.py
+++ b/htm.it/htm/it/app/aws/elb_utils.py
@@ -26,7 +26,7 @@ import time
 
 import boto.ec2.elb
 from boto.exception import (AWSConnectionError, BotoServerError)
-from nupic.support import decorators
+from nta.utils.error_handling import retry
 
 from htm.it.app import config
 
@@ -103,13 +103,13 @@ def retryOnELBTransientError(logger=logging.root,
 
     return True
 
-  return decorators.retry(
+  return retry(
     timeoutSec=timeoutSec,
     initialRetryDelaySec=INITIAL_RETRY_BACKOFF_SEC,
     maxRetryDelaySec=MAX_RETRY_BACKOFF_SEC,
     retryExceptions=RETRY_EXCEPTIONS,
     retryFilter=retryFilter,
-    getLoggerCallback=lambda: logger,
+    logger=logger,
     clientLabel="retryOnELBTransientError")
 
 

--- a/htm.it/htm/it/app/aws/opsworks_utils.py
+++ b/htm.it/htm/it/app/aws/opsworks_utils.py
@@ -24,7 +24,7 @@
 import logging
 
 from boto.exception import (AWSConnectionError, BotoServerError)
-from nupic.support import decorators
+from nta.utils.error_handling import retry
 
 
 class OpsWorksClientErrorCodes(object):
@@ -112,11 +112,11 @@ def retryOnOpsworksTransientError(logger=logging.root,
 
     return True
 
-  return decorators.retry(
+  return retry(
     timeoutSec=timeoutSec,
     initialRetryDelaySec=INITIAL_RETRY_BACKOFF_SEC,
     maxRetryDelaySec=MAX_RETRY_BACKOFF_SEC,
     retryExceptions=RETRY_EXCEPTIONS,
     retryFilter=retryFilter,
-    getLoggerCallback=lambda: logger,
+    logger=logger,
     clientLabel="retryOnOpsWorksTransientError")

--- a/htm.it/htm/it/app/aws/rds_utils.py
+++ b/htm.it/htm/it/app/aws/rds_utils.py
@@ -26,7 +26,7 @@ import time
 
 import boto.ec2
 from boto.exception import (AWSConnectionError, BotoServerError)
-from nupic.support import decorators
+from nta.utils import error_handling
 
 from htm.it.app import config
 
@@ -107,13 +107,13 @@ def retryOnRDSTransientError(logger=logging.root,
 
     return True
 
-  return decorators.retry(
+  return error_handling.retry(
     timeoutSec=timeoutSec,
     initialRetryDelaySec=INITIAL_RETRY_BACKOFF_SEC,
     maxRetryDelaySec=MAX_RETRY_BACKOFF_SEC,
     retryExceptions=RETRY_EXCEPTIONS,
     retryFilter=retryFilter,
-    getLoggerCallback=lambda: logger,
+    logger=logger,
     clientLabel="retryOnCloudWatchTransientError")
 
 

--- a/htm.it/htm/it/app/aws/s3_utils.py
+++ b/htm.it/htm/it/app/aws/s3_utils.py
@@ -27,7 +27,7 @@ import socket
 from boto.exception import (AWSConnectionError, BotoServerError,
                             S3CreateError, S3DataError, S3ResponseError)
 
-from nupic.support import decorators
+from nta.utils.error_handling import retry
 
 DEFAULT_RETRY_TIMEOUT_SEC = 20.0
 
@@ -114,8 +114,10 @@ def retryOnBotoS3TransientError(getLoggerCallback=logging.getLogger,
     S3ResponseError,
   ])
 
-  return decorators.retry(
+  logger = getLoggerCallback()
+
+  return retry(
     timeoutSec=timeoutSec, initialRetryDelaySec=0.1, maxRetryDelaySec=10,
     retryExceptions=retryExceptions, retryFilter=retryFilter,
-    getLoggerCallback=getLoggerCallback,
+    logger=logger,
     clientLabel="retryOnBotoS3TransientError")

--- a/htm.it/tests/py/integration/app/runtime/metric_collector_int_test.py
+++ b/htm.it/tests/py/integration/app/runtime/metric_collector_int_test.py
@@ -40,7 +40,7 @@ import unittest
 from htm.it.app.quota import Quota
 
 
-from nupic.support.decorators import retry
+from nta.utils.error_handling import retry
 
 from nta.utils.message_bus_connector import MessageBusConnector
 from nta.utils.test_utils import ManagedSubprocessTerminator


### PR DESCRIPTION
Fixes https://jira.numenta.com/browse/ENG-51
This is the next PR for this issue after #412 had to be reverted by #415 

This passes all tests for htm.it and all but one test for taurus, which also fails on master, as described in: https://jira.numenta.com/browse/TAUR-1578

@scottpurdy This is ready for review.