### PR TITLE
ENG-85 Address Scott's feedback regarding log-level logic in SlotAgent._runEventLoop.stopModel closure. Add unit test for failed model runner.

### DIFF
--- a/htmengine/htmengine/model_swapper/slot_agent.py
+++ b/htmengine/htmengine/model_swapper/slot_agent.py
@@ -25,7 +25,6 @@ execution slot within a Model Scheduler service instance.
 """
 
 import errno
-import logging
 import os
 import Queue
 import signal
@@ -350,9 +349,14 @@ class SlotAgent(object):
           "%r: {TAG:SWAP.SA.MODEL.STOP.PENDING} modelState=%r",
           self, modelState)
         modelState.modelExitStatus = modelState.modelRunner.stopGracefully()
-        self._logger.log(
-          logging.INFO if modelState.modelExitStatus == 0 else logging.ERROR,
-          "%r: {TAG:SWAP.SA.MODEL.STOP.DONE} modelState=%r", self, modelState)
+
+        if modelState.modelExitStatus == 0:
+          self._logger.info("%r: {TAG:SWAP.SA.MODEL.STOP.DONE} modelState=%r",
+                            self, modelState)
+        else:
+          self._logger.error("%r: {TAG:SWAP.SA.MODEL.STOP.DONE} modelState=%r",
+                             self, modelState)
+
         if doCallback:
           modelState.modelFinishedCallback(modelState.modelExitStatus)
 
@@ -425,6 +429,6 @@ class _CurrentModelState(object):
   def __repr__(self):
     return ("%s<modelID=%s, stopPend=%s, stopReq=%s, modelFailed=%s, "
             "exitStatus=%s, modelRunner=%r>") % (
-      self.__class__.__name__, self.modelID, self.stopModelPending,
-      self.stopModelRequested, self.modelFailed, self.modelExitStatus,
-      self.modelRunner)
+              self.__class__.__name__, self.modelID, self.stopModelPending,
+              self.stopModelRequested, self.modelFailed, self.modelExitStatus,
+              self.modelRunner)


### PR DESCRIPTION
@scottpurdy, please review. This addresses your feedback from #446