### PR TITLE
ENG-95 Override Taurus Engine's REST API Key in Taurus pipelines

### DIFF
--- a/nta.utils/nta/utils/config.py
+++ b/nta.utils/nta/utils/config.py
@@ -165,8 +165,23 @@ class Config(ConfigParser, object):
     self.loadConfig()
 
 
+  def __repr__(self):
+    return "{cls}<name={name}, mode={mode}, baseDir={baseDir}>".format(
+      cls=self.__class__.__name__,
+      name=self._configName,
+      mode=self._mode,
+      baseDir=self.baseConfigDir)
+
+
+  # TODO ENG-96 - CONFIG_NAME is deprecated: it doesn't follow our coding
+  #   conventions for naming instance-level properties. Use configName instead.
   @property
   def CONFIG_NAME(self):
+    return self._configName
+
+
+  @property
+  def configName(self):
     return self._configName
 
 

--- a/nta.utils/tests/unit/config_test.py
+++ b/nta.utils/tests/unit/config_test.py
@@ -104,6 +104,29 @@ class ConfigTest(unittest.TestCase):
       environPatch.stop()
 
 
+  def testRepr(self):
+
+    configName = "test.conf"
+    with self._redirectConfigBase(configName,
+                                  _SAMPLE_CONF_CONTENTS) as baseConfigDir:
+      conf = config.Config(configName, baseConfigDir)
+
+      reprText = repr(conf)
+      self.assertEqual(
+        reprText,
+        "Config<name=test.conf, mode=1, baseDir={}>".format(baseConfigDir))
+
+
+  def testConfigNamePropertyGetter(self):
+
+    configName = "test.conf"
+    with self._redirectConfigBase(configName,
+                                  _SAMPLE_CONF_CONTENTS) as baseConfigDir:
+      conf = config.Config(configName, baseConfigDir)
+
+      self.assertEqual(conf.configName, configName)
+
+
   def testHierarchicalConfigNameTypeError(self):
     # Expects TypeError when given configName is hierarchical
     configName = "a/b/c/hieararchical_config_name.conf"

--- a/taurus.metric_collectors/tests/deployment/resource_accessibility_test.py
+++ b/taurus.metric_collectors/tests/deployment/resource_accessibility_test.py
@@ -40,12 +40,13 @@ from nta.utils import error_reporting
 from nta.utils.message_bus_connector import MessageBusConnector
 
 from taurus.metric_collectors import collectorsdb
+from taurus.metric_collectors import metric_utils
 from taurus.metric_collectors.xignite import xignite_stock_agent
 
 
-_ACCESSIBILITY_TIMEOUT_SEC = 10
+_ACCESSIBILITY_TIMEOUT_SEC = 20
 
-_RETRY_SERVICE_RUNNING_CHECK = error_handling.retry(
+_RETRY_ACCESSIBILITY_CHECK = error_handling.retry(
   _ACCESSIBILITY_TIMEOUT_SEC,
   initialRetryDelaySec=1,
   maxRetryDelaySec=1)
@@ -55,18 +56,19 @@ _RETRY_SERVICE_RUNNING_CHECK = error_handling.retry(
 class TaurusMetricCollectorsResourceAccessibilityTestCase(unittest.TestCase):
 
 
-  @_RETRY_SERVICE_RUNNING_CHECK
+  @_RETRY_ACCESSIBILITY_CHECK
   def testCollectorsdbIsAccessible(self):  # pylint: disable=R0201
     transactionContext = collectorsdb.engineFactory().begin()
     transactionContext.transaction.rollback()
 
 
-  @_RETRY_SERVICE_RUNNING_CHECK
+  @_RETRY_ACCESSIBILITY_CHECK
   def testMessageBusIsAccessible(self):  # pylint: disable=R0201
     with MessageBusConnector() as bus:
       bus.isMessageQeueuePresent("")
 
 
+  # Twitter API sometimes throttles for a while, so we use longer retries
   @error_handling.retry(timeoutSec=90,
                         initialRetryDelaySec=2,
                         maxRetryDelaySec=2)
@@ -120,7 +122,7 @@ class TaurusMetricCollectorsResourceAccessibilityTestCase(unittest.TestCase):
     self.fail("Unexpected return of control from stream.filter()")
 
 
-  @_RETRY_SERVICE_RUNNING_CHECK
+  @_RETRY_ACCESSIBILITY_CHECK
   def testXigniteSecuritiesInterfaceIsAccessible(self):
 
     def getData(formattedStartTime, formattedEndTime):
@@ -163,13 +165,21 @@ class TaurusMetricCollectorsResourceAccessibilityTestCase(unittest.TestCase):
         data = getData(formattedStartTime, formattedEndTime)
         endTime -= timedelta(days=1)
 
-    self.assertEqual(data["Outcome"], "Success",
+    self.assertEqual(
+      data["Outcome"], "Success",
       ("Unable to query the XIgnite API for recent data for AAPL between {} "
        "and now").format(startTime))
 
 
-  @_RETRY_SERVICE_RUNNING_CHECK
-  def testSendErrorEmailIsPossible(self):
+  @_RETRY_ACCESSIBILITY_CHECK
+  def testTaurusEngineRestApiIsAccessible(self): # pylint: disable=R0201
+    metric_utils.getAllCustomMetrics(
+      host=os.environ["TAURUS_HTM_SERVER"],
+      apiKey=os.environ["TAURUS_API_KEY"])
+
+
+  @_RETRY_ACCESSIBILITY_CHECK
+  def testSendErrorEmailIsPossible(self): # pylint: disable=R0201
     """Send email to devnull@numenta.com via error-reporting email mechanism"""
     params = error_reporting._getErrorReportingParamsFromEnv()
     params["recipients"][:] = ["devnull@numenta.com"]
@@ -177,6 +187,7 @@ class TaurusMetricCollectorsResourceAccessibilityTestCase(unittest.TestCase):
     error_reporting.sendErrorEmail(subject="testSendErrorEmailIsPossible",
                                    body="Testing testSendErrorEmailIsPossible",
                                    params=params)
+
 
 
 

--- a/taurus/conf/application.conf
+++ b/taurus/conf/application.conf
@@ -40,7 +40,6 @@ plaintext_port = 2003
 queue_name = taurus.metric.custom.data
 
 [security]
-# TAUR-1065 Remove this from the conf file and replace with something else (env var??)
 apikey = taurus
 
 [anomaly_likelihood]

--- a/taurus/pipeline/scripts/initialize-remote-taurus-servers.sh
+++ b/taurus/pipeline/scripts/initialize-remote-taurus-servers.sh
@@ -326,6 +326,8 @@ pushd "${REPOPATH}"
         --host=${DYNAMODB_HOST} \
         --port=${DYNAMODB_PORT} \
         --table-suffix=${DYNAMODB_TABLE_SUFFIX} &&
+     taurus-set-api-key \
+        --apikey=%{TAURUS_API_KEY} &&
      cd /opt/numenta/products/taurus/taurus/engine/repository &&
      python migrate.py &&
      cd /opt/numenta/products/taurus &&

--- a/taurus/pipeline/scripts/refresh-remote-taurus-servers.sh
+++ b/taurus/pipeline/scripts/refresh-remote-taurus-servers.sh
@@ -344,6 +344,8 @@ pushd "${REPOPATH}"
         --host=${DYNAMODB_HOST} \
         --port=${DYNAMODB_PORT} \
         --table-suffix=${DYNAMODB_TABLE_SUFFIX} &&
+     taurus-set-api-key \
+        --apikey=%{TAURUS_API_KEY} &&
      cd /opt/numenta/products/taurus/taurus/engine/repository &&
      python migrate.py &&
      cd /opt/numenta/products/taurus &&

--- a/taurus/pipeline/scripts/update-remote-taurus-servers.sh
+++ b/taurus/pipeline/scripts/update-remote-taurus-servers.sh
@@ -334,6 +334,8 @@ pushd "${REPOPATH}"
         --host=${DYNAMODB_HOST} \
         --port=${DYNAMODB_PORT} \
         --table-suffix=${DYNAMODB_TABLE_SUFFIX} &&
+     taurus-set-api-key \
+        --apikey=%{TAURUS_API_KEY} &&
      cd /opt/numenta/products/taurus/taurus/engine/repository &&
      python migrate.py &&
      cd /opt/numenta/products/taurus &&

--- a/taurus/setup.py
+++ b/taurus/setup.py
@@ -18,6 +18,7 @@ setup(
       "taurus-create-db = %s.engine.repository:reset" % name,
       ("taurus-set-dynamodb = "
        "%s.engine.runtime.dynamodb.set_dynamodb_credentials:main") % name,
+      "taurus-set-api-key = %s.engine.set_api_key:main" % name,
       "taurus-set-rabbitmq = %s.engine.set_rabbitmq_login:main" % name,
       "taurus-set-sql-login = %s.engine.repository.set_sql_login:main" % name
     ]

--- a/taurus/taurus/engine/set_api_key.py
+++ b/taurus/taurus/engine/set_api_key.py
@@ -1,0 +1,87 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Applies the given Taurus REST API key as override for application.conf."""
+
+
+import logging
+import __main__
+import argparse
+
+from nta.utils.config import Config
+
+import taurus.engine
+from taurus.engine import logging_support
+
+
+
+g_log = logging.getLogger(__name__)
+
+
+
+def main():
+  logging_support.LoggingSupport().initTool()
+
+
+  parser = argparse.ArgumentParser(description=__main__.__doc__)
+
+  parser.add_argument(
+    "--apikey",
+    required=True,
+    dest="apikey",
+    metavar="API_KEY",
+    help=("Taurus Engine's REST API key"))
+
+  args = parser.parse_args()
+
+  if not args.apikey:
+    msg = "Missing or empty api key"
+    g_log.error(msg)
+    parser.error(msg)
+
+
+  conf = taurus.engine.config
+
+  assert conf.has_section("security"), (
+    "Section 'security' is not in {}".format(conf))
+
+  assert conf.has_option("security", "apikey"), (
+    "security/apikey option is not in {}".format(conf))
+
+
+  confWriter = Config(configName=conf.configName,
+                      baseConfigDir=conf.baseConfigDir,
+                      mode=Config.MODE_OVERRIDE_ONLY)
+
+  if not confWriter.has_section("security"):
+    confWriter.add_section("security")
+
+  confWriter.set("security", "apikey", args.apikey)
+
+  confWriter.save()
+
+  g_log.info(
+    "Override of Taurus Engine REST API key completed successfully via %r",
+    confWriter)
+
+
+if __name__ == "__main__":
+  main()

--- a/taurus/taurus/engine/set_rabbitmq_login.py
+++ b/taurus/taurus/engine/set_rabbitmq_login.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
 # Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from

--- a/taurus/tests/unit/set_api_key_test.py
+++ b/taurus/tests/unit/set_api_key_test.py
@@ -1,0 +1,59 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Unit test for taurus.engine.set_api_key.py"""
+
+# Disable pylint message concerning "method could be a function
+# pylint: disable=R0201
+
+import unittest
+
+from mock import patch
+
+import taurus.engine
+from taurus.engine import set_api_key
+
+
+
+@patch("taurus.engine.set_api_key.logging_support", autospec=True)
+class SetApiKeyTestCase(unittest.TestCase):
+
+
+  @patch("taurus.engine.set_api_key.Config", autospec=True)
+  def testMain(self, configClassMock, _loggingSupportMock):
+
+    with patch("sys.argv", new=["testapp", "--apikey", "54321"]):
+      set_api_key.main()
+
+      configClassMock.assert_called_with(
+        configName=taurus.engine.config.configName,
+        baseConfigDir=taurus.engine.config.baseConfigDir,
+        mode=configClassMock.MODE_OVERRIDE_ONLY)
+
+      configClassMock.return_value.set.assert_called_once_with("security",
+                                                               "apikey",
+                                                               "54321")
+      configClassMock.return_value.save.assert_called_once_with()
+
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
ENG-95 Impelement taurus-set-api-key console script for overriding Taurus Engine's REST API Key.

ENG-95 Updated Taurus pipeline scripts to override Taurus Engine's REST API Key using the new tool.