### PR TITLE
Improve logging of models deleted by metric_maintenance_agent

### DIFF
--- a/taurus.metric_collectors/taurus/metric_collectors/delete_companies.py
+++ b/taurus.metric_collectors/taurus/metric_collectors/delete_companies.py
@@ -143,9 +143,13 @@ def deleteCompanies(tickerSymbols,
 
   # NOTE: We must query custom metrics after flushing the metric data path,
   # since metrics may get created as a side-effect of processing metric data.
-  allMetricNames = tuple(
-    obj["name"] for obj in
-    metric_utils.getAllCustomMetrics(host=engineServer, apiKey=engineApiKey))
+  allMetricsMap = {
+    obj["name"] : obj
+    for obj in
+    metric_utils.getAllCustomMetrics(host=engineServer, apiKey=engineApiKey)
+  }
+
+  allMetricNames = allMetricsMap.keys()
 
   for symbolNum, symbol in enumerate(tickerSymbols, 1):
     # Delete corresponding metrics from Taurus Engine
@@ -165,7 +169,8 @@ def deleteCompanies(tickerSymbols,
       metric_utils.deleteMetric(host=engineServer,
                                 apiKey=engineApiKey,
                                 metricName=metricName)
-      g_log.info("Deleted metric=%s", metricName)
+      g_log.info("Deleted metric name=%s, uid=%s", metricName,
+                 allMetricsMap[metricName]["uid"])
 
 
     # Delete the symbol from xignite_security table last; this cascades to

--- a/taurus.metric_collectors/tests/unit/delete_companies_test.py
+++ b/taurus.metric_collectors/tests/unit/delete_companies_test.py
@@ -29,6 +29,7 @@ Unit tests for taurus.metric_collectors.delete_companies
 
 import time
 import unittest
+import uuid
 
 import mock
 from mock import ANY, Mock, patch
@@ -83,7 +84,8 @@ class DeleteCompaniesTestCase(unittest.TestCase):
 
     # Patch getAllCustomMetrics to return all negatives and positives
     getAllCustomMetricsMock.return_value = [
-      {"name": metric} for metric in negatives.union(positives)
+      {"uid": uuid.uuid1().hex, "name": metric}
+      for metric in negatives.union(positives)
     ]
 
     # Simulate xitgnite_security found for first symbol, but not the second one.
@@ -150,7 +152,8 @@ class DeleteCompaniesTestCase(unittest.TestCase):
 
     # Patch getAllCustomMetrics to return all negatives and positives
     getAllCustomMetricsMock.return_value = [
-      {"name": metric} for metric in negatives.union(positives)
+      {"uid": uuid.uuid1().hex, "name": metric}
+      for metric in negatives.union(positives)
     ]
 
     engineFactoryMock.return_value.begin.return_value.__enter__.return_value \

--- a/taurus/taurus/engine/runtime/dynamodb/dynamodb_service.py
+++ b/taurus/taurus/engine/runtime/dynamodb/dynamodb_service.py
@@ -486,9 +486,10 @@ class DynamoDBService(object):
     """ Purge metric from dynamodb metric table
     :param uid: Metric uid
     """
-    g_log.info("Removing %s from dynamodb", uid)
+    g_log.info("Handling `deleteModel` for %s", uid)
     try:
       metricItem = self._metric.lookup(uid, consistent=True)
+      g_log.info("Deleting %r from dynamodb", metricItem)
       metricItem.delete()
     except ItemNotFound as err:
       g_log.warning("Nothing to remove.  %s", str(err))


### PR DESCRIPTION
After deploying https://jira.numenta.com/browse/TAUR-964 to production via http://jenkins-master.numenta.com/job/graceful-update-production-taurus-servers/19/, I tried to validate the expected company changes by correlated references to them in dynamodb_service and metric_maintenance_agent logs.

It turned out to be difficult, since metric_maintenance_agent logged just the metric name of the deleted model, while dynamoddb_service logged just the unique id.

This PR addresses the shortcoming.