### PR TITLE
Use forked cxfreeze in which use of shutil.copystat() is optional, al…

### DIFF
--- a/unicorn/py/requirements.txt
+++ b/unicorn/py/requirements.txt
@@ -1,4 +1,4 @@
--e https://bitbucket.org/oxtopus/cx_freeze/get/sip.tar.gz#egg=cx_Freeze-5.0
+https://bitbucket.org/oxtopus/cx_freeze/get/sip.tar.gz#egg=cx_Freeze-5.0
 validictory==0.9.1
 
 # NuPIC HTM

--- a/unicorn/py/requirements.txt
+++ b/unicorn/py/requirements.txt
@@ -1,4 +1,4 @@
-cx_freeze==4.3.4
+-e https://bitbucket.org/oxtopus/cx_freeze/get/sip.tar.gz#egg=cx_Freeze-5.0
 validictory==0.9.1
 
 # NuPIC HTM

--- a/unicorn/py/unicorn_backend/freeze_model_runner.py
+++ b/unicorn/py/unicorn_backend/freeze_model_runner.py
@@ -122,6 +122,7 @@ def main():
                                                  "prettytable"],
                               zipIncludes=zipIncludes,
                               includeFiles=includeFiles,
+                              includeStat=False,
                               silent=True)
 
   freezer.Freeze()


### PR DESCRIPTION
…lowing use on OS X El Capitan

cc @lscheinkman 