### PR TITLE
Remove unused logging AWS credentials from Taurus.

### DIFF
--- a/taurus/docker/taurus/conf/application.conf
+++ b/taurus/docker/taurus/conf/application.conf
@@ -42,10 +42,6 @@ queue_name = taurus.metric.custom.data
 [security]
 apikey = taurus
 
-[logging]
-s3_access_key_id = AKIAISDCY6XZFBW5QUYQ
-s3_secret_access_key = 4/BfUWLTYn5+V5Eqm6tIC7Rq9aMN2ryt4ST7ASde
-
 [anomaly_likelihood]
 # Minimal sample size for statistic calculation
 statistics_min_sample_size=100


### PR DESCRIPTION
fixes ENG-104

@vitaly-krugl please review