### PR TITLE
ENG-84 Fix race condition in taurus update pipeline's server stop/start logic

### DIFF
--- a/nta.utils/nta/utils/tools/supervisord_state.py
+++ b/nta.utils/nta/utils/tools/supervisord_state.py
@@ -22,6 +22,7 @@
 """Get state of supervisord"""
 
 from argparse import ArgumentParser
+import errno
 import socket
 import sys
 import time
@@ -133,11 +134,13 @@ def waitForStoppedStateMain():
   for i in xrange(1, maxWaitCycles + 2):
     try:
       getSupervisordState(args.supervisorApiUrl)
-    except (socket.error, xmlrpclib.Fault):
-      # API is no longer available at specified supervisorApiUrl.  It is safe
-      # to assume that IF the supervisordApiUrl is correct, that supervisor is
-      # not running.  In which case, break out of loop and return.
-      break
+    except socket.error as exc:
+      if exc.errno == errno.ECONNREFUSED:
+        # API is no longer available at specified supervisorApiUrl.  Assuming
+        # that if the supervisordApiUrl is correct, then connection refusal
+        # indicates that supervisord is not running.
+        print "Supervisord stop detected via exception={!r}".format(exc)
+        break
 
     if i <= maxWaitCycles:
       print "Waiting for supervisord to stop..."

--- a/taurus/pipeline/scripts/refresh-remote-taurus-servers.sh
+++ b/taurus/pipeline/scripts/refresh-remote-taurus-servers.sh
@@ -214,7 +214,7 @@ pushd "${REPOPATH}"
 
   fi
 
-  # Shutdown services
+  # Stop taurus metric collector server
   ssh -v -t ${SSH_ARGS} "${TAURUS_COLLECTOR_USER}"@"${TAURUS_COLLECTOR_HOST}" \
     "cd /opt/numenta/products/taurus.metric_collectors &&
      if [ -f supervisord.pid ]; then
@@ -222,7 +222,7 @@ pushd "${REPOPATH}"
        nta-wait-for-supervisord-stopped http://localhost:8001
      fi"
 
-  # Stop taurus server instance
+  # Stop taurus engine server
   ssh -v -t ${SSH_ARGS} "${TAURUS_SERVER_USER}"@"${TAURUS_SERVER_HOST}" \
     "cd /opt/numenta/products/taurus &&
      if [ -f taurus-supervisord.pid ]; then
@@ -341,6 +341,7 @@ pushd "${REPOPATH}"
      cd /opt/numenta/products/taurus &&
      sudo /usr/sbin/nginx -p . -c conf/nginx-taurus.conf &&
      supervisord -c conf/supervisord.conf &&
+     nta-wait-for-supervisord-running http://localhost:9001 &&
      ${TAURUS_ENGINE_TESTS}"
 
   # Perform Collector update, start Collector
@@ -368,8 +369,6 @@ pushd "${REPOPATH}"
         --user=${RABBITMQ_USER} \
         --password=${RABBITMQ_PASSWD} &&
      cd /opt/numenta/products/taurus.metric_collectors &&
-     supervisorctl --serverurl http://localhost:8001 shutdown &&
-     nta-wait-for-supervisord-stopped http://localhost:8001 &&
      py.test tests/deployment/resource_accessibility_test.py &&
      supervisord -c conf/supervisord.conf &&
      nta-wait-for-supervisord-running http://localhost:8001 &&


### PR DESCRIPTION
CC @scottpurdy, @oxtopus

ENG-84 Cleaned up server stop/start logic in update-remote-taurus-servers.sh.

ENG-84 Added necessary nta-wait-for-supervisord-stopped to eliminate stop/start race condition.

ENG-84 In nta.utils.tools.supervisord_state.waitForStoppedStateMain, wait only for socket.error to conclude that supervisord is not available in order to eliminate race condition with re-starting logic.
ENG-84 Removed unnecessary supervisord shutdown of metric collector before running resource accessibility test, since the server was already shut down at the top of the script.