### PR TITLE
Fix misspelled assert function names in htm.it unit tests

### DIFF
--- a/htm.it/tests/py/unit/app/aws/asg_utils_test.py
+++ b/htm.it/tests/py/unit/app/aws/asg_utils_test.py
@@ -43,7 +43,7 @@ class ASGUtilsTest(unittest.TestCase):
     suggestions = list(suggestions)
 
     self.assertSequenceEqual(suggestions, [])
-    getAutoScalingGroupsMock.assert_call_once_with("dummy-region")
+    getAutoScalingGroupsMock.assert_called_once_with("dummy-region")
 
 
   @patch("htm.it.app.aws.asg_utils.getAutoScalingGroups")
@@ -73,7 +73,7 @@ class ASGUtilsTest(unittest.TestCase):
         {"id": "testName1", "name": "testName1", "namespace": "AWS/AutoScaling",
          "region": region},
     ])
-    getAutoScalingGroupsMock.assert_call_once_with(region)
+    getAutoScalingGroupsMock.assert_called_once_with(region)
 
 
 

--- a/htm.it/tests/py/unit/app/aws/ec2_utils_test.py
+++ b/htm.it/tests/py/unit/app/aws/ec2_utils_test.py
@@ -43,7 +43,7 @@ class EC2UtilsTest(unittest.TestCase):
     suggestions = list(suggestions)
 
     self.assertSequenceEqual(suggestions, [])
-    getEC2InstancesMock.assert_call_once_with("dummy-region")
+    getEC2InstancesMock.assert_called_once_with("dummy-region")
 
 
   @patch("htm.it.app.aws.ec2_utils.getEC2Instances")
@@ -59,7 +59,7 @@ class EC2UtilsTest(unittest.TestCase):
     suggestions = list(suggestions)
 
     self.assertSequenceEqual(suggestions, [])
-    getEC2InstancesMock.assert_call_once_with("dummy-region")
+    getEC2InstancesMock.assert_called_once_with("dummy-region")
 
 
   @patch("htm.it.app.aws.ec2_utils.getEC2Instances")
@@ -97,7 +97,7 @@ class EC2UtilsTest(unittest.TestCase):
         {"id": "testId1", "name": "testName1", "namespace": "AWS/EC2",
          "region": regionMock.name},
     ])
-    getEC2InstancesMock.assert_call_once_with(regionMock.name)
+    getEC2InstancesMock.assert_called_once_with(regionMock.name)
 
 
   @patch("htm.it.app.aws.ec2_utils.getEC2Instances")
@@ -135,7 +135,7 @@ class EC2UtilsTest(unittest.TestCase):
         {"id": "testId2", "name": "testName2", "namespace": "AWS/EC2",
          "region": regionMock.name},
     ])
-    getEC2InstancesMock.assert_call_once_with(regionMock.name)
+    getEC2InstancesMock.assert_called_once_with(regionMock.name)
 
 
 

--- a/htm.it/tests/py/unit/app/aws/elb_utils_test.py
+++ b/htm.it/tests/py/unit/app/aws/elb_utils_test.py
@@ -43,7 +43,7 @@ class ELBUtilsTest(unittest.TestCase):
     suggestions = list(suggestions)
 
     self.assertSequenceEqual(suggestions, [])
-    getELBInstancesMock.assert_call_once_with("dummy-region")
+    getELBInstancesMock.assert_called_once_with("dummy-region")
 
 
   @patch("htm.it.app.aws.elb_utils.getELBInstances")
@@ -73,7 +73,7 @@ class ELBUtilsTest(unittest.TestCase):
         {"id": "testName1", "name": "testName1", "namespace": "AWS/ELB",
          "region": region},
     ])
-    getELBInstancesMock.assert_call_once_with(region)
+    getELBInstancesMock.assert_called_once_with(region)
 
 
 

--- a/htm.it/tests/py/unit/app/aws/rds_utils_test.py
+++ b/htm.it/tests/py/unit/app/aws/rds_utils_test.py
@@ -43,7 +43,7 @@ class RDSUtilsTest(unittest.TestCase):
     suggestions = list(suggestions)
 
     self.assertSequenceEqual(suggestions, [])
-    getRDSInstancesMock.assert_call_once_with("dummy-region")
+    getRDSInstancesMock.assert_called_once_with("dummy-region")
 
 
   @patch("htm.it.app.aws.rds_utils.getRDSInstances")
@@ -59,7 +59,7 @@ class RDSUtilsTest(unittest.TestCase):
     suggestions = list(suggestions)
 
     self.assertSequenceEqual(suggestions, [])
-    getRDSInstancesMock.assert_call_once_with("dummy-region")
+    getRDSInstancesMock.assert_called_once_with("dummy-region")
 
 
   @patch("htm.it.app.aws.rds_utils.getRDSInstances")
@@ -91,7 +91,7 @@ class RDSUtilsTest(unittest.TestCase):
         {"id": "testId1", "name": "testId1", "namespace": "AWS/RDS",
          "region": region},
     ])
-    getRDSInstancesMock.assert_call_once_with(region)
+    getRDSInstancesMock.assert_called_once_with(region)
 
 
 

--- a/htm.it/tests/py/unit/app/runtime/aggregation_test.py
+++ b/htm.it/tests/py/unit/app/runtime/aggregation_test.py
@@ -193,7 +193,7 @@ class GetStatisticsTest(unittest.TestCase):
 
     metricGetterMock.collectMetricStatistics.assert_called_once_with(
         autostackMock, metricRowMock)
-    metricGetterMock.close.assert_called_once()
+    metricGetterMock.close.assert_called_once_with()
 
 
   @patch("htm.it.app.runtime.aggregation.repository")
@@ -237,7 +237,7 @@ class GetStatisticsTest(unittest.TestCase):
 
     metricGetterMock.collectMetricStatistics.assert_called_once_with(
         autostackMock, metricRowMock)
-    metricGetterMock.close.assert_called_once()
+    metricGetterMock.close.assert_called_once_with()
 
 
   @patch("htm.it.app.runtime.aggregation.repository.engineFactory", autospec=True)
@@ -285,7 +285,7 @@ class GetStatisticsTest(unittest.TestCase):
 
     metricGetterMock.collectMetricStatistics.assert_called_once_with(
         autostackMock, metricRowMock)
-    metricGetterMock.close.assert_called_once()
+    metricGetterMock.close.assert_called_once_with()
 
 
 

--- a/htm.it/tests/py/unit/app/webservices/logging_api_test.py
+++ b/htm.it/tests/py/unit/app/webservices/logging_api_test.py
@@ -67,7 +67,7 @@ class AndroidHandlerTest(unittest.TestCase):
         response = logging_api.AndroidHandler.POST()
 
     # Verify results
-    dataMock.assert_called_once()
+    dataMock.assert_called_once_with()
     openMock.assert_called_with(logging_api._LOG_FORMAT_ANDROID, "a")
     handle = openMock()
     handle.write.assert_called_once_with("%s [INFO] "
@@ -124,8 +124,8 @@ class FeedbackHandlerTest(unittest.TestCase):
     response = logging_api.FeedbackHandler.POST()
 
     # Verify results
-    dataMock.assert_called_once()
-    uploadTarfileMock.assert_called_once()
+    dataMock.assert_called_once_with()
+    self.assertEqual(uploadTarfileMock.call_count, 1)
     self.assertEqual(response, "s3_key")
 
 


### PR DESCRIPTION
CC @scottpurdy 