### PR TITLE
IMBU-83 #comment Fix table header height in Firefox, now matches across browsers.

### DIFF
--- a/imbu/gui/browser/components/search-results.jsx
+++ b/imbu/gui/browser/components/search-results.jsx
@@ -148,7 +148,7 @@ export default class SearchResultsComponent extends React.Component {
         </select>
 
         <Table selectable={false} fixedHeader={true}
-          height={styles.table.height} ref="results" style={styles.table}>
+          height={styles.table.height} ref="results">
           <TableHeader  adjustForCheckbox={false} displaySelectAll={false}>
             <TableRow>
               <TableHeaderColumn key={0} style={styles.column.summary}>


### PR DESCRIPTION
IMBU-83 #comment Fix table header height in Firefox, now matches across browsers.

https://jira.numenta.com/browse/IMBU-83