### PR TITLE
UNI-300 Implemented model_runner per phase 2 ModelRunner interface specification

### DIFF
--- a/unicorn/js/config/momentjs_to_datetime_strptime.json
+++ b/unicorn/js/config/momentjs_to_datetime_strptime.json
@@ -1,0 +1,42 @@
+{
+  "ISO 8601": {
+    "YYYY-MM-DDTHH:mm:ss.SZ": "%Y-%m-%dT%H:%M:%S.%fZ",
+    "YYYY-MM-DDTHH:mm:ss.S": "%Y-%m-%dT%H:%M:%S.%f",
+    "YYYY-MM-DDTHH:mm:ssZ": "%Y-%m-%dT%H:%M:%SZ",
+    "YYYY-MM-DDTHH:mm:ss": "%Y-%m-%dT%H:%M:%S",
+    "YYYY-MM-DDTHH:mmZ": "%Y-%m-%dT%H:%MZ",
+    "YYYY-MM-DDTHH:mm": "%Y-%m-%dT%H:%M"
+  },
+
+  "ISO 8601 no T": {
+    "YYYY-MM-DD HH:mm:ss.SZ": "%Y-%m-%d %H:%M:%S.%fZ",
+    "YYYY-MM-DD HH:mm:ss.S": "%Y-%m-%d %H:%M:%S.%f",
+    "YYYY-MM-DD HH:mm:ssZ": "%Y-%m-%d %H:%M:%SZ",
+    "YYYY-MM-DD HH:mm:ss": "%Y-%m-%d %H:%M:%S",
+    "YYYY-MM-DD HH:mmZ": "%Y-%m-%d %H:%MZ",
+    "YYYY-MM-DD HH:mm": "%Y-%m-%d %H:%M",
+    "YYYY-MM-DD": "%Y-%m-%d"
+  },
+
+  "US Date, 24h time": {
+    "MM-DD-YYYY HH:mm:ss.S": "%m-%d-%Y %H:%M:%S.%f",
+    "MM-DD-YYYY HH:mm:ss": "%m-%d-%Y %H:%M:%S",
+    "MM-DD-YYYY HH:mm": "%m-%d-%Y %H:%M"
+  },
+
+  "US Date": {
+    "MM-DD-YYYY": "%m-%d-%Y"
+  },
+
+  "US 12h AM/PM time": {
+    "hh:mm:ss.S A": "%i:%M:%S.%f %p",
+    "hh:mm:ss A": "%i:%M:%S %p",
+    "hh:mm A": "%i:%M %p"
+  },
+
+  "24h time": {
+    "HH:mm:ss.S": "%H:%M:%S.%f",
+    "HH:mm:ss": "%H:%M:%S",
+    "HH:mm": "%H:%M"
+  }
+}

--- a/unicorn/py/requirements.txt
+++ b/unicorn/py/requirements.txt
@@ -1,4 +1,5 @@
 cx_freeze==4.3.4
+python-dateutil==2.1
 validictory==0.9.1
 
 # NuPIC HTM

--- a/unicorn/py/unicorn_backend/agg_opt_schema.json
+++ b/unicorn/py/unicorn_backend/agg_opt_schema.json
@@ -1,0 +1,19 @@
+{
+  "description": "--agg command-line option object passed to model runner; describes the aggregation",
+  "type": "object",
+  "additionalProperties": false,
+
+  "properties": {
+    "windowSize": {
+      "description": "Aggregation window size in seconds",
+      "type": "integer",
+      "required": true
+    },
+    "func": {
+      "description": "A string representation of the aggregation function; compatible with those expected by the `nupic.data.aggregator` module",
+      "type": "string",
+      "enum": ["sum", "mean"],
+      "required": true
+    }
+  }
+}

--- a/unicorn/py/unicorn_backend/input_opt_schema.json
+++ b/unicorn/py/unicorn_backend/input_opt_schema.json
@@ -1,0 +1,28 @@
+{
+  "description": "--input command-line option object passed to model runner",
+  "type": "object",
+  "additionalProperties": false,
+
+  "properties": {
+    "rowOffset": {
+      "description": "index of first data row in CSV file; zero-based",
+      "type": "integer",
+      "required": true
+    },
+    "timestampIndex": {
+      "description": "Column index of the timestamp; zero-based",
+      "type": "integer",
+      "required": true
+    },
+    "valueIndex": {
+      "description": "Column index of the value; zero-based",
+      "type": "integer",
+      "required": true
+    },
+    "datetimeFormat": {
+      "description": "Datetime Format for datetime.strptime",
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/unicorn/py/unicorn_backend/model_opt_schema.json
+++ b/unicorn/py/unicorn_backend/model_opt_schema.json
@@ -1,0 +1,33 @@
+{
+  "description": "--model command-line option object passed to model runner",
+  "type": "object",
+  "additionalProperties": false,
+
+  "properties": {
+    "modelId": {
+      "description": "The model id; ModelRunner uses the model id for logging",
+      "type": "string",
+      "required": true
+    },
+    "modelConfig": {
+      "description": "OPF Model Configuration parameters (JSON object) for passing to the OPF `ModelFactory.create()` method as the `modelConfig` parameter.",
+      "type": "object",
+      "required": true
+    },
+    "inferenceArgs": {
+      "description": "OPF Model Inference parameters (JSON object) for passing to the resulting model's `enableInference()` method as the `inferenceArgs` parameter.",
+      "type": "object",
+      "required": true
+    },
+    "timestampFieldName": {
+      "description": "The name of the field in modelParams corresponding to the metric timestamp; for example, this is c0 in the model params returned by nupic.frameworks.opf.common_models.cluster_params.getScalarMetricWithTimeOfDayAnomalyParams().",
+      "type": "string",
+      "required": true
+    },
+    "valueFieldName": {
+      "description": "The name of the field in modelParams corresponding to the metric value; for example, this is c1 in the model params returned by nupic.frameworks.opf.common_models.cluster_params.getScalarMetricWithTimeOfDayAnomalyParams().",
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/unicorn/py/unicorn_backend/model_runner_2.py
+++ b/unicorn/py/unicorn_backend/model_runner_2.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Implements Unicorn's ModelRunner interface, Phase-2 specification.
+
+Date format resources:
+
+* http://www.uai.cl/images/sitio/biblioteca/citas/ISO_8601_2004en.pdf
+
+* NOTE: dateutil parser doesn't support decimal comma yet (in master, but not
+released)
+
+* https://www.ietf.org/rfc/rfc3339.txt
+
+"""
+from argparse import ArgumentParser
+import csv
+from datetime import datetime
+import json
+import logging
+import os
+import pkg_resources
+import sys
+import traceback
+
+import validictory
+
+from nupic.algorithms.anomaly_likelihood import AnomalyLikelihood
+from nupic.data import aggregator
+from nupic.data import fieldmeta
+from nupic.data import record_stream
+from nupic.frameworks.opf.modelfactory import ModelFactory
+
+
+
+g_log = logging.getLogger(__name__)
+
+
+
+class _CommandLineArgError(Exception):
+  """ Error parsing command-line options """
+  pass
+
+
+
+class _Options(object):
+  """Options returned by _parseArgs"""
+
+
+  def __init__(self, inputSpec, aggSpec, modelSpec):
+    """
+    :param dict inputSpec: Input data specification per input_opt_schema.json
+    :param dict aggSpec: Optional aggregation specification per
+      agg_otp_schema.json or None if no aggregation is requested
+    :param dict modelSpec: Model specification per model_opt_schema.json
+    """
+    self.inputSpec = inputSpec
+    self.aggSpec = aggSpec
+    self.modelSpec = modelSpec
+
+
+
+def _parseArgs():
+  """ Parse command-line args
+
+  :rtype: _Options object
+  :raises _CommandLineArgError: on command-line arg error
+  """
+  class SilentArgumentParser(ArgumentParser):
+    def error(self, msg):
+      """Override `error()` to prevent unstructured output to stderr"""
+      raise _CommandLineArgError(msg)
+
+  parser = SilentArgumentParser(description=("Start Unicorn ModelRunner that "
+                                             "runs a single model."))
+
+  parser.add_argument(
+    "--input",
+    type=str,
+    dest="inputSpec",
+    required=True,
+    help=("REQUIRED: JSON object describing the input metric data per "
+          "input_opt_schema.json"))
+
+  parser.add_argument(
+    "--agg",
+    type=str,
+    dest="aggSpec",
+    required=False,
+    default=None,
+    help=("OPTIONAL: JSON object describing aggregation of the input metric "
+          "data per agg_opt_schema.json; if omitted, aggregation of input data "
+          "will be bypassed."))
+
+  parser.add_argument(
+    "--model",
+    type=str,
+    dest="modelSpec",
+    required=False,
+    default=None,
+    help=("REQUIRED: JSON object describing the model per "
+          "model_opt_schema.json."))
+
+  options = parser.parse_args()
+
+
+  # Input spec is required
+  try:
+    inputSpec = json.loads(options.inputSpec)
+  except ValueError as exc:
+    g_log.exception("JSON parsing of --input value failed")
+    parser.error("--input option value failed JSON parsing: {}".format(exc))
+
+  with pkg_resources.resource_stream(__name__,
+                                     "input_opt_schema.json") as schemaFile:
+    try:
+      validictory.validate(inputSpec, json.load(schemaFile))
+    except validictory.ValidationError as exc:
+      g_log.exception("JSON schema validation of --input value failed")
+      parser.error("JSON schema validation of --input value failed: {}"
+                   .format(exc))
+
+
+  # Aggregation spec is optional
+  aggSpec = options.aggSpec
+  if aggSpec is not None:
+    try:
+      aggSpec = json.loads(aggSpec)
+    except ValueError as exc:
+      g_log.exception("JSON parsing of --agg value failed")
+      parser.error("--agg option value failed JSON parsing: {}".format(exc))
+
+    with pkg_resources.resource_stream(__name__,
+                                       "agg_opt_schema.json") as schemaFile:
+      try:
+        validictory.validate(aggSpec, json.load(schemaFile))
+      except validictory.ValidationError as exc:
+        g_log.exception("JSON schema validation of --agg value failed")
+        parser.error("JSON schema validation of --agg value failed: {}"
+                     .format(exc))
+
+
+  # Model spec is required
+  try:
+    modelSpec = json.loads(options.modelSpec)
+  except ValueError as exc:
+    g_log.exception("JSON parsing of modelSpec failed")
+    parser.error("--model option value failed JSON parsing: %r" % (exc,))
+
+  with pkg_resources.resource_stream(__name__,
+                                     "model_opt_schema.json") as schemaFile:
+    try:
+      validictory.validate(modelSpec, json.load(schemaFile))
+    except validictory.ValidationError as exc:
+      g_log.exception("JSON schema validation of --model value failed")
+      parser.error("JSON schema validation of --model value failed: {}"
+                   .format(exc))
+
+
+  return _Options(inputSpec=inputSpec, aggSpec=aggSpec, modelSpec=modelSpec)
+
+
+
+class _ModelRunner(object):
+  """ Use OPF Model to process metric data samples from stdin and and emit
+  anomaly likelihood results to stdout
+  """
+
+
+  def __init__(self, inputFileObj, inputSpec, aggSpec, modelSpec):
+    """
+    :param inputFileObj: A file-like object that contains input metric data
+    :param dict inputSpec: Input data specification per input_opt_schema.json
+    :param dict aggSpec: Optional aggregation specification per
+      agg_otp_schema.json or None if no aggregation is requested
+    :param dict modelSpec: Model specification per model_opt_schema.json
+    """
+    self._inputSpec = inputSpec
+
+    self._aggSpec = aggSpec
+
+    self._modelSpec = modelSpec
+    self._modelId = modelSpec["modelId"]
+
+
+    inputRecordSchema = (
+      fieldmeta.FieldMetaInfo(modelSpec["timestampFieldName"],
+                              fieldmeta.FieldMetaType.datetime,
+                              fieldmeta.FieldMetaSpecial.timestamp),
+      fieldmeta.FieldMetaInfo(modelSpec["valueFieldName"],
+                              fieldmeta.FieldMetaType.float,
+                              fieldmeta.FieldMetaSpecial.none),
+    )
+
+    self._aggregator = aggregator.Aggregator(
+      aggregationInfo=dict(
+        fields=([(modelSpec["valueFieldName"], aggSpec["func"])]
+                if aggSpec is not None else []),
+        seconds=aggSpec["windowSize"] if aggSpec is not None else 0
+      ),
+      inputFields=inputRecordSchema)
+
+    self._modelRecordEncoder = record_stream.ModelRecordEncoder(
+      fields=inputRecordSchema)
+
+    self._model = self._createModel(modelSpec=modelSpec)
+
+    self._anomalyLikelihood = AnomalyLikelihood()
+
+    self._csvReader = self._createCsvReader(inputFileObj)
+
+
+  @staticmethod
+  def _createModel(modelSpec):
+    """Instantiate and configure an OPF model
+
+    :param dict modelSpec: Model specification per model_opt_schema.json
+
+    :returns: OPF Model instance
+    """
+
+    model = ModelFactory.create(modelConfig=modelSpec["modelConfig"])
+    model.enableLearning()
+    model.enableInference(modelSpec["inferenceArgs"])
+
+    return model
+
+
+  @staticmethod
+  def _createCsvReader(fileObj):
+    # We'll be operating on csvs with arbitrarily long fields
+    csv.field_size_limit(2**27)
+
+    # Make sure readline() works on windows too
+    os.linesep = "\n"
+
+    return csv.reader(fileObj, dialect="excel")
+
+
+  @classmethod
+  def _emitOutputMessage(cls, dataRow, anomalyProbability):
+    """Emit output message to stdout
+
+    :param list dataRow: the two-tuple data row on which anomalyProbability was
+      computed, whose first element is datetime timestamp and second element is
+      the float scalar value
+    :param float anomalyProbability: computed anomaly probability value
+    """
+    message = "{}\n".format(
+      json.dumps([dataRow[0].isoformat(), dataRow[1], anomalyProbability]))
+
+    sys.stdout.write(message)
+    sys.stdout.flush()
+
+
+  def _computeAnomalyProbability(self, fields):
+    """ Compute anomaly log likelihood score
+
+    :param tuple fields: Two-tuple input metric data row
+      (<datetime-timestamp>, <float-scalar>)
+
+    :returns: Log-scaled anomaly probability
+    :rtype: float
+    """
+    # Generate raw anomaly score
+    inputRecord = self._modelRecordEncoder.encode(fields)
+    rawAnomalyScore = self._model.run(inputRecord).inferences["anomalyScore"]
+
+    # Generate anomaly likelihood score
+    anomalyProbability = self._anomalyLikelihood.anomalyProbability(
+      value=fields[1],
+      anomalyScore=rawAnomalyScore,
+      timestamp=fields[0])
+
+    return self._anomalyLikelihood.computeLogLikelihood(anomalyProbability)
+
+
+  def run(self):
+    """ Run the model: ingest and process the input metric data and emit output
+    messages containing anomaly scores
+    """
+
+    numRowsToSkip = self._inputSpec["rowOffset"]
+    datetimeFormat = self._inputSpec["datetimeFormat"]
+    inputRowTimestampIndex = self._inputSpec["timestampIndex"]
+    inputRowValueIndex = self._inputSpec["valueIndex"]
+
+    g_log.info("Processing model=%s", self._modelId)
+
+    for inputRow in self._csvReader:
+      g_log.debug("Got inputRow=%r", inputRow)
+
+      if numRowsToSkip > 0:
+        numRowsToSkip -= 1
+        g_log.debug("Skipping header row %s; %s rows left to skip",
+                    inputRow, numRowsToSkip)
+        continue
+
+      # Extract timestamp and value
+      # NOTE: the order must match the `inputFields` that we passed to the
+      # Aggregator constructor
+      fields = [
+        datetime.strptime(inputRow[inputRowTimestampIndex], datetimeFormat),
+        float(inputRow[inputRowValueIndex])
+      ]
+
+      # Aggregate
+      aggRow, _ = self._aggregator.next(fields, None)
+      g_log.debug("Aggregator returned %s for %s", aggRow, fields)
+      if aggRow is not None:
+        self._emitOutputMessage(
+          dataRow=aggRow,
+          anomalyProbability=self._computeAnomalyProbability(aggRow))
+
+
+    # Reap remaining data from aggregator
+    aggRow, _ = self._aggregator.next(None, curInputBookmark=None)
+    g_log.debug("Aggregator reaped %s in final call", aggRow)
+    if aggRow is not None:
+      self._emitOutputMessage(
+        dataRow=aggRow,
+        anomalyProbability=self._computeAnomalyProbability(aggRow))
+
+
+
+class _UnbufferedLineIterInputFile(object):
+  """Enable unbuffered line iteration from a file.
+
+  This wrapper class enables line-level iteration over a file without waiting
+  for a "hidden" buffer in file I/O to be filled, thus facilitating full-duplex
+  operation. Example usage:
+
+  for line in _UnbufferedLineIterInputFile(sys.stdin):
+    print line
+
+  Without this helper class, `for line in sys.stdin: print line` blocks to fill
+  a hiden buffer in file I/O before returning any lines
+  """
+
+
+  def __init__(self, fileObj):
+    self.fileObj = fileObj
+
+
+  def __iter__(self):
+    return self
+
+
+  def next(self):
+    line = self.fileObj.readline()
+    if not line:
+      raise StopIteration
+
+    return line
+
+
+  def __getattr__(self, attr):
+    return getattr(self.fileObj, attr)
+
+
+
+def main():
+  # Use NullHandler for now to avoid getting the unwanted unformatted warning
+  # message from logger on stderr "No handlers could be found for logger".
+  g_log.addHandler(logging.NullHandler())
+  try:
+    options = _parseArgs()
+
+    # Create an input file object with the desired properties
+    inputFileObj = os.fdopen(os.dup(sys.stdin.fileno()), "rU")
+
+    # Invoke the model runner
+    _ModelRunner(
+      inputFileObj=inputFileObj,
+      inputSpec=options.inputSpec,
+      aggSpec=options.aggSpec,
+      modelSpec=options.modelSpec).run()
+  except Exception as ex:  # pylint: disable=W0703
+    g_log.exception("ModelRunner failed")
+
+    errorMessage = {
+      "errorText": str(ex) or repr(ex),
+      "diagnosticInfo": traceback.format_exc()
+    }
+
+    errorMessage = "%s\n" % (json.dumps(errorMessage))
+
+    try:
+      sys.stderr.write(errorMessage)
+      sys.stderr.flush()
+    except Exception:  # pylint: disable=W0703
+      g_log.exception("Failed to emit error message to stderr; msg=%s",
+                      errorMessage)
+
+    # Use os._exit to abort the process instead of an exception to prevent
+    # the python runtime from dumping traceback to stderr (since we dump a json
+    # message to stderr, and don't want the extra text to interfere with parsing
+    # in the Front End)
+    os._exit(1)  # pylint: disable=W0212
+
+
+
+if __name__ == "__main__":
+  main()

--- a/unicorn/py/unicorn_backend/tests/integration/model_runner_2_test.py
+++ b/unicorn/py/unicorn_backend/tests/integration/model_runner_2_test.py
@@ -1,0 +1,623 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Intergration test of the unicorn_backend.model_runner module"""
+
+from datetime import datetime
+from datetime import timedelta
+import json
+import logging
+import subprocess
+import sys
+import types
+import unittest
+import uuid
+
+import dateutil.parser
+
+from nupic.frameworks.opf.common_models.cluster_params import (
+  getScalarMetricWithTimeOfDayAnomalyParams)
+from nta.utils.logging_support_raw import LoggingSupport
+from nta.utils import test_utils
+
+
+
+_LOGGER = logging.getLogger("unicorn_model_runner_test")
+
+
+
+def setUpModule():
+  LoggingSupport.initTestApp()
+
+
+
+class ModelRunnerTestCase(unittest.TestCase):
+
+
+  def setUp(self):
+    swarmParams = getScalarMetricWithTimeOfDayAnomalyParams(
+      metricData=[0],
+      minVal=0,
+      maxVal=100,
+      minResolution=None)
+
+    self.modelConfig = swarmParams["modelConfig"]
+    self.inferenceArgs = swarmParams["inferenceArgs"]
+    self.timestampFieldName = "c0"
+    self.valueFieldName = "c1"
+
+
+  @staticmethod
+  def _startModelRunnerSubprocess(inputOpt, modelOpt, aggOpt):
+    """Start the unicorn model_runner subprocess
+
+    :param dict inputOpt: input options per input_opt_schema.json
+    :param dict modelOpt: input options per model_opt_schema.json
+    :param dict aggOpt: aggregation options per agg_opt_schema.json; None if no
+      aggregation
+    :returns: the started subprocess.Popen object wrapped in
+      ManagedSubprocessTerminator
+    :rtype: nta.utils.test_utils.ManagedSubprocessTerminator
+    """
+    args = [
+      sys.executable,
+      "-m", "unicorn_backend.model_runner_2",
+      "--input={}".format(json.dumps(inputOpt)),
+      "--model={}".format(json.dumps(modelOpt)),
+    ]
+
+    if aggOpt is not None:
+      args.append("--agg={}".format(json.dumps(aggOpt)))
+
+    process = subprocess.Popen(
+      args=args,
+      stdin=subprocess.PIPE,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      close_fds=True)
+
+    _LOGGER.info("Started unicorn model_runner subprocess=%s", process)
+    return test_utils.ManagedSubprocessTerminator(process)
+
+
+  def testStartAndStopModelRunnerNoAggregationOption(self):
+    modelId = uuid.uuid1().hex
+
+    inputOpt = dict(
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=None) as mrProcess:
+      # Close the subprocess's stdin and wait for it to terminate
+      mrProcess.stdin.close()
+      mrProcess.wait()
+
+      stdoutData = mrProcess.stdout.read()
+      stderrData = mrProcess.stderr.read()
+
+      self.assertEqual(stdoutData, "")
+      self.assertEqual(stderrData, "")
+
+      self.assertEqual(mrProcess.returncode, 0)
+
+
+  def testStartAndStopModelRunnerWithAggregationOption(self):
+    modelId = uuid.uuid1().hex
+
+    inputOpt = dict(
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    aggOpt = dict(
+      windowSize=300,
+      func="sum"
+    )
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=aggOpt) as mrProcess:
+      # Close the subprocess's stdin and wait for it to terminate
+      mrProcess.stdin.close()
+      mrProcess.wait()
+
+      stdoutData = mrProcess.stdout.read()
+      stderrData = mrProcess.stderr.read()
+
+      self.assertEqual(stdoutData, "")
+      self.assertEqual(stderrData, "")
+
+      self.assertEqual(mrProcess.returncode, 0)
+
+
+  def testModelRunnerFailsWithInvalidInputOpt(self):
+    modelId = uuid.uuid1().hex
+
+    inputOpt = None
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=None) as mrProcess:
+      # Wait for it to terminate with error
+      stdoutData, stderrData = mrProcess.communicate()
+
+      self.assertEqual(mrProcess.returncode, 1)
+
+      self.assertEqual(stdoutData, "")
+
+      # Validate error info
+      try:
+        errorInfo = json.loads(stderrData)
+      except ValueError:
+        _LOGGER.exception("Failed while decoding model-runner's stderr=%s",
+                          stderrData)
+        raise
+
+      self.assertIn("errorText", errorInfo)
+      self.assertIsInstance(errorInfo["errorText"], types.StringTypes)
+      self.assertGreater(len(errorInfo["errorText"]), 0)
+
+      self.assertIn("diagnosticInfo", errorInfo)
+      self.assertIsInstance(errorInfo["diagnosticInfo"], types.StringTypes)
+      self.assertGreater(len(errorInfo["diagnosticInfo"]), 0)
+
+
+  def testModelRunnerFailsWithInvalidModelOpt(self):
+    inputOpt = dict(
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = None
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=None) as mrProcess:
+      # Wait for it to terminate with error
+      stdoutData, stderrData = mrProcess.communicate()
+
+      self.assertEqual(mrProcess.returncode, 1)
+
+      self.assertEqual(stdoutData, "")
+
+      # Validate error info
+      try:
+        errorInfo = json.loads(stderrData)
+      except ValueError:
+        _LOGGER.exception("Failed while decoding model-runner's stderr=%s",
+                          stderrData)
+        raise
+
+      self.assertIn("errorText", errorInfo)
+      self.assertIsInstance(errorInfo["errorText"], types.StringTypes)
+      self.assertGreater(len(errorInfo["errorText"]), 0)
+
+      self.assertIn("diagnosticInfo", errorInfo)
+      self.assertIsInstance(errorInfo["diagnosticInfo"], types.StringTypes)
+      self.assertGreater(len(errorInfo["diagnosticInfo"]), 0)
+
+
+  def testModelRunnerFailsWithInvalidAggOpt(self):
+    modelId = uuid.uuid1().hex
+
+    inputOpt = dict(
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    aggOpt = ""
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=aggOpt) as mrProcess:
+      # Wait for it to terminate with error
+      stdoutData, stderrData = mrProcess.communicate()
+
+      self.assertEqual(mrProcess.returncode, 1)
+
+      self.assertEqual(stdoutData, "")
+
+      # Validate error info
+      try:
+        errorInfo = json.loads(stderrData)
+      except ValueError:
+        _LOGGER.exception("Failed while decoding model-runner's stderr=%s",
+                          stderrData)
+        raise
+
+      self.assertIn("errorText", errorInfo)
+      self.assertIsInstance(errorInfo["errorText"], types.StringTypes)
+      self.assertGreater(len(errorInfo["errorText"]), 0)
+
+      self.assertIn("diagnosticInfo", errorInfo)
+      self.assertIsInstance(errorInfo["diagnosticInfo"], types.StringTypes)
+      self.assertGreater(len(errorInfo["diagnosticInfo"]), 0)
+
+
+  def testModelRunnerFailsWithInvalidInputRecord(self):
+    modelId = uuid.uuid1().hex
+
+    inputOpt = dict(
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    aggOpt = None
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=aggOpt) as mrProcess:
+      # Wait for it to terminate with error
+      stdoutData, stderrData = mrProcess.communicate(input="[]\n")
+
+      self.assertEqual(mrProcess.returncode, 1)
+
+      self.assertEqual(stdoutData, "")
+
+      # Validate error info
+      try:
+        errorInfo = json.loads(stderrData)
+      except ValueError:
+        _LOGGER.exception("Failed while decoding model-runner's stderr=%s",
+                          stderrData)
+        raise
+
+      self.assertIn("errorText", errorInfo)
+      self.assertIsInstance(errorInfo["errorText"], types.StringTypes)
+      self.assertGreater(len(errorInfo["errorText"]), 0)
+
+      self.assertIn("diagnosticInfo", errorInfo)
+      self.assertIsInstance(errorInfo["diagnosticInfo"], types.StringTypes)
+      self.assertGreater(len(errorInfo["diagnosticInfo"]), 0)
+
+
+  def testFeedInputGetOutputWithoutAggregation(self):
+    modelId = uuid.uuid1().hex
+
+    inputOpt = dict(
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    aggOpt = None
+
+    inputRows = [
+      (datetime.utcnow(), i + 0.599) for i in xrange(10)
+    ]
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=aggOpt) as mrProcess:
+      # Send all input rows to ModelRunner for processing
+      inputString = "\n".join(
+        "{},{}".format(inTimestamp.isoformat(), inValue)
+        for inTimestamp, inValue in inputRows)
+
+      _LOGGER.debug("Sending to ModelRunner: %r", inputString)
+
+      mrProcess.stdin.write(inputString)
+      mrProcess.stdin.close()
+
+
+      for inTimestamp, inValue in inputRows:
+        # Read output row and validate
+        outputRecord = mrProcess.stdout.readline()
+
+        _LOGGER.debug("Got result=%r", outputRecord)
+
+        outTimestamp, outValue, anomalyLikelihood = json.loads(outputRecord)
+
+        self.assertEqual(dateutil.parser.parse(outTimestamp), inTimestamp)
+        self.assertEqual(outValue, inValue)
+        self.assertIsInstance(anomalyLikelihood, float)
+
+
+      # Wait for subprocess to terminate
+      mrProcess.wait()
+      stdoutData = mrProcess.stdout.read()
+      stderrData = mrProcess.stderr.read()
+
+      self.assertEqual(stdoutData, "")
+      self.assertEqual(stderrData, "")
+
+      self.assertEqual(mrProcess.returncode, 0)
+
+
+  def testFeedInputGetOutputWithNonReducingAggregation(self):
+    modelId = uuid.uuid1().hex
+
+    inputOpt = dict(
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    aggOpt = dict(
+      windowSize=300,
+      func="sum"
+    )
+
+    now = datetime.utcnow()
+
+    # Set up timestamps far enough apart such that aggregation should have no
+    # effect
+    inputRows = [
+      (now + timedelta(seconds=aggOpt["windowSize"] * i), i + 0.599)
+      for i in xrange(10)
+    ]
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=aggOpt) as mrProcess:
+      # Send all input rows to ModelRunner for processing
+      inputString = "\n".join(
+        "{},{}".format(inTimestamp.isoformat(), inValue)
+        for inTimestamp, inValue in inputRows)
+
+      _LOGGER.debug("Sending to ModelRunner: %r", inputString)
+
+      mrProcess.stdin.write(inputString)
+      mrProcess.stdin.close()
+
+
+      for inTimestamp, inValue in inputRows:
+        # Read output row and validate
+        outputRecord = mrProcess.stdout.readline()
+
+        _LOGGER.debug("Got result=%r", outputRecord)
+
+        outTimestamp, outValue, anomalyLikelihood = json.loads(outputRecord)
+
+        self.assertEqual(dateutil.parser.parse(outTimestamp), inTimestamp)
+        self.assertEqual(outValue, inValue)
+        self.assertIsInstance(anomalyLikelihood, float)
+
+
+      # Wait for subprocess to terminate
+      mrProcess.wait()
+      stdoutData = mrProcess.stdout.read()
+      stderrData = mrProcess.stderr.read()
+
+      self.assertEqual(stdoutData, "")
+      self.assertEqual(stderrData, "")
+
+      self.assertEqual(mrProcess.returncode, 0)
+
+
+  def testFeedInputGetOutputWithReducingSumAggregation(self):
+    modelId = uuid.uuid1().hex
+
+    inputOpt = dict(
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    aggOpt = dict(
+      windowSize=300,
+      func="sum"
+    )
+
+    now = datetime.utcnow()
+
+    # Set up timestamps such that aggregation will reduce number of samples
+    inputRows = [
+      (now + timedelta(seconds=100 * i), i + 0.599)
+      for i in xrange(10)
+    ]
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=aggOpt) as mrProcess:
+      # Send all input rows to ModelRunner for processing
+      inputString = "\n".join(
+        "{},{}".format(inTimestamp.isoformat(), inValue)
+        for inTimestamp, inValue in inputRows)
+
+      _LOGGER.debug("Sending to ModelRunner: %r", inputString)
+
+      mrProcess.stdin.write(inputString)
+      mrProcess.stdin.close()
+
+
+      # Validate aggregations
+      for i in xrange((len(inputRows) + 2) // 3):
+        # Read output row and validate
+        outputRecord = mrProcess.stdout.readline()
+
+        _LOGGER.debug("Got result=%r", outputRecord)
+
+        outTimestamp, outValue, anomalyLikelihood = json.loads(outputRecord)
+
+        aggSlice = inputRows[i*3:i*3+3]
+
+        self.assertEqual(dateutil.parser.parse(outTimestamp), aggSlice[0][0])
+
+        self.assertEqual(outValue, sum(row[1] for row in aggSlice))
+
+        self.assertIsInstance(anomalyLikelihood, float)
+
+
+      # Wait for subprocess to terminate
+      mrProcess.wait()
+      stdoutData = mrProcess.stdout.read()
+      stderrData = mrProcess.stderr.read()
+
+      self.assertEqual(stdoutData, "")
+      self.assertEqual(stderrData, "")
+
+      self.assertEqual(mrProcess.returncode, 0)
+
+
+  def testFeedInputGetOutputWithReducingMeanAggregation(self):
+    modelId = uuid.uuid1().hex
+
+    inputOpt = dict(
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    aggOpt = dict(
+      windowSize=300,
+      func="mean"
+    )
+
+    now = datetime.utcnow()
+
+    # Set up timestamps such that aggregation will reduce number of samples
+    inputRows = [
+      (now + timedelta(seconds=100 * i), i + 0.599)
+      for i in xrange(10)
+    ]
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=aggOpt) as mrProcess:
+      # Send all input rows to ModelRunner for processing
+      inputString = "\n".join(
+        "{},{}".format(inTimestamp.isoformat(), inValue)
+        for inTimestamp, inValue in inputRows)
+
+      _LOGGER.debug("Sending to ModelRunner: %r", inputString)
+
+      mrProcess.stdin.write(inputString)
+      mrProcess.stdin.close()
+
+
+      # Validate aggregations
+      for i in xrange((len(inputRows) + 2) // 3):
+        # Read output row and validate
+        outputRecord = mrProcess.stdout.readline()
+
+        _LOGGER.debug("Got result=%r", outputRecord)
+
+        outTimestamp, outValue, anomalyLikelihood = json.loads(outputRecord)
+
+        aggSlice = inputRows[i*3:i*3+3]
+
+        self.assertEqual(dateutil.parser.parse(outTimestamp), aggSlice[0][0])
+
+        self.assertEqual(outValue,
+                         sum(row[1] for row in aggSlice) / len(aggSlice))
+
+        self.assertIsInstance(anomalyLikelihood, float)
+
+
+      # Wait for subprocess to terminate
+      mrProcess.wait()
+      stdoutData = mrProcess.stdout.read()
+      stderrData = mrProcess.stderr.read()
+
+      self.assertEqual(stdoutData, "")
+      self.assertEqual(stderrData, "")
+
+      self.assertEqual(mrProcess.returncode, 0)

--- a/unicorn/py/unicorn_backend/tests/unit/model_runner_2_test.py
+++ b/unicorn/py/unicorn_backend/tests/unit/model_runner_2_test.py
@@ -1,0 +1,74 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Unit test of the unicorn_backend.model_runner_2 module"""
+
+import logging
+from mock import patch
+import sys
+import unittest
+
+##from nta.utils.logging_support_raw import LoggingSupport
+from unicorn_backend import model_runner_2
+
+
+
+_LOGGER = logging.getLogger("unicorn_model_runner_2_test")
+
+
+
+##def setUpModule():
+##  LoggingSupport.initTestApp()
+
+
+
+class ModelRunnerTestCase(unittest.TestCase):
+
+  def testParseArgs(self):
+    """ Invalid CLI arguments are rejected
+    """
+
+    def _assertArgumentPatternFails(argumentPattern=None):
+      if argumentPattern is None:
+        argumentPattern = []
+
+      argumentPattern = ["unicorn_backend/model_runner_2.py"] + argumentPattern
+
+      with patch.object(sys, "argv", argumentPattern):
+        # pylint: disable=W0212
+        with self.assertRaises(model_runner_2._CommandLineArgError):
+          model_runner_2._parseArgs()
+
+    _assertArgumentPatternFails()
+
+    _assertArgumentPatternFails(["--input="])
+    _assertArgumentPatternFails(['--input="1"'])
+    _assertArgumentPatternFails(['--input="{}"'])
+
+    _assertArgumentPatternFails(["--agg="])
+    _assertArgumentPatternFails(['--agg="1"'])
+    _assertArgumentPatternFails(['--agg="{}"'])
+
+    _assertArgumentPatternFails(["--model="])
+    _assertArgumentPatternFails(['--model="1"'])
+    _assertArgumentPatternFails(['--model="{}"'])
+
+    _assertArgumentPatternFails(['--input="{}"', '--model="{}"'])


### PR DESCRIPTION
CC @scottpurdy @marionleborgne @ywcui1990 

The new Model Runner module is initially named `model_runner_2.py`, while we still have the original around. We can get rid of the old and rename the new module after FrontEnd integrates with the new Model Runner.