### PR TITLE
UNI-305 Convert all CSV input to unix newlines

### DIFF
--- a/unicorn/js/browser/actions/FileUpload.js
+++ b/unicorn/js/browser/actions/FileUpload.js
@@ -215,6 +215,7 @@ export default function (actionContext, file) {
     log.debug('NO file is not already in DB, get from upload');
     fileFormatted = yield csp.take(getFileFromUpload(opts));
     if (fileFormatted instanceof Error) {
+      console.error(fileFormatted);
       actionContext.dispatch(ACTIONS.UPLOADED_FILE_FAILED, {
         error: fileFormatted,
         filename: file.name

--- a/unicorn/js/browser/actions/ListMetrics.js
+++ b/unicorn/js/browser/actions/ListMetrics.js
@@ -65,8 +65,11 @@ export default function (actionContext, files) {
         let fileCount = 0;
 
         files.forEach((file) => {
+          console.error('file', file);
           fileClient.getFields(file.filename, (error, fields) => {
+            console.error('fields', file.filename, error, fields);
             if (error) {
+              console.error(error);
               actionContext.dispatch(
                 ACTIONS.LIST_METRICS_FAILURE,
                 new FilesystemGetError(error)
@@ -83,6 +86,7 @@ export default function (actionContext, files) {
                 log.debug('got files from fs, saving to db for next runs');
                 databaseClient.putMetricBatch(fieldsList, (error) => {
                   if (error) {
+                    console.error(error);
                     actionContext.dispatch(
                       ACTIONS.LIST_METRICS_FAILURE,
                       new DatabasePutError(error)

--- a/unicorn/js/browser/actions/ListMetrics.js
+++ b/unicorn/js/browser/actions/ListMetrics.js
@@ -65,9 +65,7 @@ export default function (actionContext, files) {
         let fileCount = 0;
 
         files.forEach((file) => {
-          console.error('file', file);
           fileClient.getFields(file.filename, (error, fields) => {
-            console.error('fields', file.filename, error, fields);
             if (error) {
               console.error(error);
               actionContext.dispatch(

--- a/unicorn/js/main/FileService.js
+++ b/unicorn/js/main/FileService.js
@@ -22,15 +22,13 @@
 // NOTE: Must be ES5 for now, Electron's `remote` does not like ES6 Classes!
 /* eslint-disable no-var, object-shorthand, prefer-arrow-callback */
 
-// externals
 
 import csv from 'csv-streamify';
 import filesystem from 'fs';
+import newline from 'newline';
 import path from 'path';
 import TimeAggregator from './TimeAggregator';
 import Utils from './Utils';
-
-// internals
 
 const SAMPLES_FILE_PATH = path.join(__dirname, '..', 'samples');
 
@@ -120,6 +118,8 @@ FileService.prototype.getFields = function (filename, options, callback) {
   var fields = [];
   var fieldName, stream;
 
+  console.error('getFields NEWLINE!!!');
+
   // "options" is optional
   if (typeof callback == 'undefined' && typeof options == 'function') {
     callback = options;
@@ -129,8 +129,9 @@ FileService.prototype.getFields = function (filename, options, callback) {
   if (!('columns' in options)) {
     options.columns = true;
   }
-
   options.objectMode = true;
+  options.newline = Utils.mapNewline(newline.detect(path.resolve(filename)));
+
   stream = filesystem.createReadStream(path.resolve(filename));
   stream.pipe(csv(options))
     .once('data', function (data) {
@@ -213,6 +214,7 @@ FileService.prototype.getData = function (filename, options, callback) {
   if (!('limit' in options)) {
     options.limit = Number.MAX_SAFE_INTEGER;
   }
+  options.newline = Utils.mapNewline(newline.detect(path.resolve(filename)));
 
   let limit = options.limit;
   let fileStream = filesystem.createReadStream(path.resolve(filename));

--- a/unicorn/js/main/Utils.js
+++ b/unicorn/js/main/Utils.js
@@ -72,6 +72,19 @@ export default class Utils {
   }
 
   /**
+   * Map newline letter representations to character slash-based representations
+   * @param {String} type - Short string 'CR', 'LF', 'CRLF'
+   * @returns {String} - Translated line ending '\r', '\n', '\r\n'
+   */
+  static mapNewline(type) {
+    return {
+      CR: '\r',
+      LF: '\n',
+      CRLF: '\r\n'
+    }[type];
+  }
+
+  /**
    * Template String to trim extra spaces from multiline es6 strings.
    * @param {Array} strings - Input string literals for es6 template string.
    * @param {...Array} [values] - Template string filler values.

--- a/unicorn/js/main/Utils.js
+++ b/unicorn/js/main/Utils.js
@@ -72,19 +72,6 @@ export default class Utils {
   }
 
   /**
-   * Map newline letter representations to character slash-based representations
-   * @param {String} type - Short string 'CR', 'LF', 'CRLF'
-   * @returns {String} - Translated line ending '\r', '\n', '\r\n'
-   */
-  static mapNewline(type) {
-    return {
-      CR: '\r',
-      LF: '\n',
-      CRLF: '\r\n'
-    }[type];
-  }
-
-  /**
    * Template String to trim extra spaces from multiline es6 strings.
    * @param {Array} strings - Input string literals for es6 template string.
    * @param {...Array} [values] - Template string filler values.

--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -90,6 +90,7 @@
     "material-ui": "0.13.4",
     "moment": "2.10.6",
     "nconf": "0.8.2",
+    "newline": "0.0.3",
     "react": "0.14.3",
     "react-addons-create-fragment": "0.14.3",
     "react-addons-pure-render-mixin": "0.14.3",

--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -72,6 +72,7 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
     "bunyan": "1.5.1",
+    "convert-newline": "0.0.5",
     "csv-streamify": "3.0.3",
     "dygraphs": "1.1.1",
     "fbjs": "0.5.1",
@@ -90,7 +91,6 @@
     "material-ui": "0.13.4",
     "moment": "2.10.6",
     "nconf": "0.8.2",
-    "newline": "0.0.3",
     "react": "0.14.3",
     "react-addons-create-fragment": "0.14.3",
     "react-addons-pure-render-mixin": "0.14.3",
@@ -125,13 +125,13 @@
     "gulp": "3.9.0",
     "gulp-util": "3.0.7",
     "json-loader": "0.5.4",
-    "lev": "3.2.3",
+    "lev": "3.3.1",
     "mocha": "2.3.4",
     "node-inspector": "0.12.5",
     "source-map-support": "0.4.0",
     "style-loader": "0.13.0",
     "url-loader": "0.5.7",
-    "webpack": "1.12.9",
+    "webpack": "1.12.12",
     "webpack-stream": "3.1.0"
   }
 }


### PR DESCRIPTION
UNI-305 #comment Convert all CSV input to unix newlines.  `CR` and `CRLF` both converted to `LF` default.

This is a first bit of progress against https://jira.numenta.com/browse/UNI-305, more PR's soon as I continue investigation.

This allows LG data to be loaded, displayed quickly, and then you can start the crawling model.

Please review @marionleborgne or @lscheinkman thanks.