### PR TITLE
UNI-316 Implemented support for timezone parsing in unicorn and integrated into model_runner_2

### DIFF
--- a/unicorn/js/config/momentjs_to_datetime_strptime.json
+++ b/unicorn/js/config/momentjs_to_datetime_strptime.json
@@ -1,42 +1,54 @@
-{
-  "ISO 8601": {
-    "YYYY-MM-DDTHH:mm:ss.SZ": "%Y-%m-%dT%H:%M:%S.%f%z",
-    "YYYY-MM-DDTHH:mm:ss.S": "%Y-%m-%dT%H:%M:%S.%f",
-    "YYYY-MM-DDTHH:mm:ssZ": "%Y-%m-%dT%H:%M:%S%z",
-    "YYYY-MM-DDTHH:mm:ss": "%Y-%m-%dT%H:%M:%S",
-    "YYYY-MM-DDTHH:mmZ": "%Y-%m-%dT%H:%M%z",
-    "YYYY-MM-DDTHH:mm": "%Y-%m-%dT%H:%M"
+[
+  {
+
+    "category": "ISO 8601",
+    "mappings": {
+      "YYYY-MM-DDTHH:mm:ss.SZ": "%Y-%m-%dT%H:%M:%S.%f%z",
+      "YYYY-MM-DDTHH:mm:ss.S": "%Y-%m-%dT%H:%M:%S.%f",
+      "YYYY-MM-DDTHH:mm:ssZ": "%Y-%m-%dT%H:%M:%S%z",
+      "YYYY-MM-DDTHH:mm:ss": "%Y-%m-%dT%H:%M:%S",
+      "YYYY-MM-DDTHH:mmZ": "%Y-%m-%dT%H:%M%z",
+      "YYYY-MM-DDTHH:mm": "%Y-%m-%dT%H:%M"
+    }
   },
 
-  "ISO 8601 no T": {
-    "YYYY-MM-DD HH:mm:ss.SZ": "%Y-%m-%d %H:%M:%S.%f%z",
-    "YYYY-MM-DD HH:mm:ss.S": "%Y-%m-%d %H:%M:%S.%f",
-    "YYYY-MM-DD HH:mm:ssZ": "%Y-%m-%d %H:%M:%S%z",
-    "YYYY-MM-DD HH:mm:ss": "%Y-%m-%d %H:%M:%S",
-    "YYYY-MM-DD HH:mmZ": "%Y-%m-%d %H:%M%z",
-    "YYYY-MM-DD HH:mm": "%Y-%m-%d %H:%M",
-    "YYYY-MM-DD": "%Y-%m-%d"
+  {
+    "category": "ISO 8601 no T",
+    "mappings": {
+      "YYYY-MM-DD HH:mm:ss.SZ": "%Y-%m-%d %H:%M:%S.%f%z",
+      "YYYY-MM-DD HH:mm:ss.S": "%Y-%m-%d %H:%M:%S.%f",
+      "YYYY-MM-DD HH:mm:ssZ": "%Y-%m-%d %H:%M:%S%z",
+      "YYYY-MM-DD HH:mm:ss": "%Y-%m-%d %H:%M:%S",
+      "YYYY-MM-DD HH:mmZ": "%Y-%m-%d %H:%M%z",
+      "YYYY-MM-DD HH:mm": "%Y-%m-%d %H:%M",
+      "YYYY-MM-DD": "%Y-%m-%d"
+    }
   },
 
-  "US Date, 24h time": {
-    "MM-DD-YYYY HH:mm:ss.S": "%m-%d-%Y %H:%M:%S.%f",
-    "MM-DD-YYYY HH:mm:ss": "%m-%d-%Y %H:%M:%S",
-    "MM-DD-YYYY HH:mm": "%m-%d-%Y %H:%M"
+  {
+    "category": "US Date, 12h AM/PM time",
+    "mappings": {
+      "MM-DD-YYYY hh:mm:ss.S A": "%m-%d-%Y %I:%M:%S.%f %p",
+      "MM-DD-YYYY hh:mm:ss A": "%m-%d-%Y %I:%M:%S %p",
+      "MM-DD-YYYY hh:mm A": "%m-%d-%Y %I:%M %p"
+    }
   },
 
-  "US Date": {
-    "MM-DD-YYYY": "%m-%d-%Y"
+  {
+    "category": "US Date, 24h time",
+    "mappings": {
+      "MM-DD-YYYY HH:mm:ss.S": "%m-%d-%Y %H:%M:%S.%f",
+      "MM-DD-YYYY HH:mm:ss": "%m-%d-%Y %H:%M:%S",
+      "MM-DD-YYYY HH:mm": "%m-%d-%Y %H:%M"
+    }
   },
 
-  "US 12h AM/PM time": {
-    "hh:mm:ss.S A": "%I:%M:%S.%f %p",
-    "hh:mm:ss A": "%I:%M:%S %p",
-    "hh:mm A": "%I:%M %p"
-  },
-
-  "24h time": {
-    "HH:mm:ss.S": "%H:%M:%S.%f",
-    "HH:mm:ss": "%H:%M:%S",
-    "HH:mm": "%H:%M"
+  {
+    "category": "US Date, no time",
+    "mappings": {
+      "MM-DD-YYYY": "%m-%d-%Y",
+      "MM-DD-YY": "%m-%d-%y"
+    }
   }
-}
+
+]

--- a/unicorn/js/config/momentjs_to_datetime_strptime.json
+++ b/unicorn/js/config/momentjs_to_datetime_strptime.json
@@ -1,19 +1,19 @@
 {
   "ISO 8601": {
-    "YYYY-MM-DDTHH:mm:ss.SZ": "%Y-%m-%dT%H:%M:%S.%fZ",
+    "YYYY-MM-DDTHH:mm:ss.SZ": "%Y-%m-%dT%H:%M:%S.%f%z",
     "YYYY-MM-DDTHH:mm:ss.S": "%Y-%m-%dT%H:%M:%S.%f",
-    "YYYY-MM-DDTHH:mm:ssZ": "%Y-%m-%dT%H:%M:%SZ",
+    "YYYY-MM-DDTHH:mm:ssZ": "%Y-%m-%dT%H:%M:%S%z",
     "YYYY-MM-DDTHH:mm:ss": "%Y-%m-%dT%H:%M:%S",
-    "YYYY-MM-DDTHH:mmZ": "%Y-%m-%dT%H:%MZ",
+    "YYYY-MM-DDTHH:mmZ": "%Y-%m-%dT%H:%M%z",
     "YYYY-MM-DDTHH:mm": "%Y-%m-%dT%H:%M"
   },
 
   "ISO 8601 no T": {
-    "YYYY-MM-DD HH:mm:ss.SZ": "%Y-%m-%d %H:%M:%S.%fZ",
+    "YYYY-MM-DD HH:mm:ss.SZ": "%Y-%m-%d %H:%M:%S.%f%z",
     "YYYY-MM-DD HH:mm:ss.S": "%Y-%m-%d %H:%M:%S.%f",
-    "YYYY-MM-DD HH:mm:ssZ": "%Y-%m-%d %H:%M:%SZ",
+    "YYYY-MM-DD HH:mm:ssZ": "%Y-%m-%d %H:%M:%S%z",
     "YYYY-MM-DD HH:mm:ss": "%Y-%m-%d %H:%M:%S",
-    "YYYY-MM-DD HH:mmZ": "%Y-%m-%d %H:%MZ",
+    "YYYY-MM-DD HH:mmZ": "%Y-%m-%d %H:%M%z",
     "YYYY-MM-DD HH:mm": "%Y-%m-%d %H:%M",
     "YYYY-MM-DD": "%Y-%m-%d"
   },
@@ -29,9 +29,9 @@
   },
 
   "US 12h AM/PM time": {
-    "hh:mm:ss.S A": "%i:%M:%S.%f %p",
-    "hh:mm:ss A": "%i:%M:%S %p",
-    "hh:mm A": "%i:%M %p"
+    "hh:mm:ss.S A": "%I:%M:%S.%f %p",
+    "hh:mm:ss A": "%I:%M:%S %p",
+    "hh:mm A": "%I:%M %p"
   },
 
   "24h time": {

--- a/unicorn/py/unicorn_backend/date_time_utils.py
+++ b/unicorn/py/unicorn_backend/date_time_utils.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Date/time-related utilities for the Unicorn project
+"""
+
+from datetime import datetime
+import re
+
+from dateutil import tz
+
+
+# +HHMM or -HHMM
+_BASIC_HHMM_UTC_OFFSET = re.compile(r"([+]|[-])(\d\d)(\d\d)$")
+
+# +HH:MM or -HH:MM
+_EXTENDED_HHMM_UTC_OFFSET = re.compile(r"([+]|[-])(\d\d):(\d\d)$")
+
+# +HH or -HH
+_ONLY_HH_UTC_OFFSET = re.compile(r"([+]|[-])(\d\d)$")
+
+
+# Based on datetime.isoformat complaint:
+#   ValueError: tzinfo.utcoffset() returned 1440; must be in -1439 .. 1439
+_MAX_UTC_OFFSET_PARTS = (24, 59)
+_MAX_UTC_OFFSET_IN_SECONDS = ((_MAX_UTC_OFFSET_PARTS[0] * 60 +
+                               _MAX_UTC_OFFSET_PARTS[1]) * 60)
+
+
+def parseDatetime(dateString, dateFormat):
+  """Supplements `datetime.strptime` functionality with the following format
+  designators:
+
+  Timezone offset %z at end of format string: accepts
+    "Z", +HHMM, +HH:MM, -HHMM, -HH:MM, +HH, -HH
+
+    NOTE: python presently supports %z in datetime.strftime, but not in
+    strptime due to lack of builtin timezone implementation
+
+
+  :param str dateString: date string to parse
+  :param str dateFormat: `datetime.strptime` format string, with the extension
+      of permitting %z at the end for UTC offset
+
+  :returns: parsed datetime; if the timestamp includes a timezone offset, the
+    result will contain the corresponding tzinfo; otherwise, the result will be
+    a naive datetime.
+  :rtype: `datetime.datetime`
+  """
+  originalDateString = dateString
+  originalDateFormat = dateFormat
+
+  # If timestamp is not naive, parse tzinfo and strip it from date and format
+  tzinfo = None
+  if dateFormat.endswith("%z"):
+    # Strip UTC offset pattern from date format so datetime.strptime won't choke
+    dateFormat = dateFormat[:-2]
+
+    if dateString.endswith("Z"):
+      tzname = "Z"
+      offsetInSeconds = 0  # Z=UTC
+
+      # Strip UTC offset from date string so datetime.strptime won't choke
+      dateString = dateString[:-1]
+
+    else:
+      parts = None
+
+      match = (_BASIC_HHMM_UTC_OFFSET.search(dateString) or
+               _EXTENDED_HHMM_UTC_OFFSET.search(dateString))
+      if match is not None:
+        parts = match.groups()
+
+      if match is None:
+        match = _ONLY_HH_UTC_OFFSET.search(dateString)
+        if match is not None:
+          parts = match.groups() + ("00",)
+
+      if match is None:
+        raise ValueError(
+          "time data {!r} does not match format {!r}".format(
+            originalDateString,
+            originalDateFormat))
+
+      tzname = match.group()
+
+      # Strip UTC offset from date string so datetime.strptime won't choke
+      dateString = dateString[:match.start()]
+
+      # Convert offset parts to offset in seconds
+      assert len(parts) == 3, len(parts)
+
+      sign, hours, minutes = parts[0], int(parts[1]), int(parts[2])
+
+      if minutes > 59:
+        raise ValueError(
+          "time data {!r} does not match format {!r}: UTC offset minutes "
+          "exceed 59".format(originalDateString, originalDateFormat))
+
+      offsetInSeconds = (hours * 60 + minutes) * 60
+      if sign == "-":
+        offsetInSeconds = -offsetInSeconds
+
+      if abs(offsetInSeconds) > _MAX_UTC_OFFSET_IN_SECONDS:
+        raise ValueError(
+          "time data {!r} does not match format {!r}: UTC offset {}{}:{} is "
+          "out of bounds; must be in -{} .. +{}"
+          .format(originalDateString, originalDateFormat,
+                  sign, hours, minutes,
+                  ":".join(_MAX_UTC_OFFSET_PARTS),
+                  ":".join(_MAX_UTC_OFFSET_PARTS)))
+
+
+    tzinfo = tz.tzoffset(name=tzname, offset=offsetInSeconds)
+
+
+  result = datetime.strptime(dateString, dateFormat)
+  if tzinfo is not None:
+    result = result.replace(tzinfo=tzinfo)
+
+  return result

--- a/unicorn/py/unicorn_backend/date_time_utils.py
+++ b/unicorn/py/unicorn_backend/date_time_utils.py
@@ -127,8 +127,8 @@ def parseDatetime(dateString, dateFormat):
           "out of bounds; must be in -{} .. +{}"
           .format(originalDateString, originalDateFormat,
                   sign, hours, minutes,
-                  ":".join(_MAX_UTC_OFFSET_PARTS),
-                  ":".join(_MAX_UTC_OFFSET_PARTS)))
+                  ":".join(str(i) for i in _MAX_UTC_OFFSET_PARTS),
+                  ":".join(str(i) for i in _MAX_UTC_OFFSET_PARTS)))
 
 
     tzinfo = tz.tzoffset(name=tzname, offset=offsetInSeconds)

--- a/unicorn/py/unicorn_backend/model_runner_2.py
+++ b/unicorn/py/unicorn_backend/model_runner_2.py
@@ -51,6 +51,8 @@ from nupic.data import fieldmeta
 from nupic.data import record_stream
 from nupic.frameworks.opf.modelfactory import ModelFactory
 
+from unicorn_backend import date_time_utils
+
 
 
 g_log = logging.getLogger(__name__)
@@ -319,7 +321,8 @@ class _ModelRunner(object):
       # NOTE: the order must match the `inputFields` that we passed to the
       # Aggregator constructor
       fields = [
-        datetime.strptime(inputRow[inputRowTimestampIndex], datetimeFormat),
+        date_time_utils.parseDatetime(inputRow[inputRowTimestampIndex],
+                                      datetimeFormat),
         float(inputRow[inputRowValueIndex])
       ]
 

--- a/unicorn/tests/py/integration/unicorn_backend/model_runner_2_test.py
+++ b/unicorn/tests/py/integration/unicorn_backend/model_runner_2_test.py
@@ -34,6 +34,7 @@ import unittest
 import uuid
 
 import dateutil.parser
+import dateutil.tz
 
 from nupic.frameworks.opf.common_models.cluster_params import (
   getScalarMetricWithTimeOfDayAnomalyParams)
@@ -625,7 +626,7 @@ class ModelRunnerTestCase(unittest.TestCase):
       self.assertEqual(mrProcess.returncode, 0)
 
 
-  def testInputViaFilePathWithHeaderGetOutputWithReducingMeanAggregation(self):
+  def testInputPathGetOutputWithHeaderAndReducingMeanAggregation(self):
     modelId = uuid.uuid1().hex
 
     csvFd, csvPath = tempfile.mkstemp()
@@ -659,6 +660,89 @@ class ModelRunnerTestCase(unittest.TestCase):
       timestampIndex=0,
       valueIndex=1,
       datetimeFormat="%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    modelOpt = dict(
+      modelId=modelId,
+      modelConfig=self.modelConfig,
+      inferenceArgs=self.inferenceArgs,
+      timestampFieldName=self.timestampFieldName,
+      valueFieldName=self.valueFieldName
+    )
+
+    aggOpt = dict(
+      windowSize=300,
+      func="mean"
+    )
+
+
+    with self._startModelRunnerSubprocess(inputOpt=inputOpt,
+                                          modelOpt=modelOpt,
+                                          aggOpt=aggOpt) as mrProcess:
+      # Validate aggregations
+      for i in xrange((len(inputRows) + 2) // 3):
+        # Read output row and validate
+        outputRecord = mrProcess.stdout.readline()
+
+        _LOGGER.debug("Got result=%r", outputRecord)
+
+        outTimestamp, outValue, anomalyLikelihood = json.loads(outputRecord)
+
+        aggSlice = inputRows[i*3:i*3+3]
+
+        self.assertEqual(dateutil.parser.parse(outTimestamp), aggSlice[0][0])
+
+        self.assertEqual(outValue,
+                         sum(row[1] for row in aggSlice) / len(aggSlice))
+
+        self.assertIsInstance(anomalyLikelihood, float)
+
+
+      # Wait for subprocess to terminate
+      mrProcess.wait()
+      stdoutData = mrProcess.stdout.read()
+      stderrData = mrProcess.stderr.read()
+
+      self.assertEqual(stdoutData, "")
+      self.assertEqual(stderrData, "")
+
+      self.assertEqual(mrProcess.returncode, 0)
+
+
+  def testInputPathGetOutputWithTimezoneAndReducingMeanAggregation(self):
+    modelId = uuid.uuid1().hex
+
+    csvFd, csvPath = tempfile.mkstemp()
+    self.addCleanup(os.unlink, csvPath)
+
+    # Populate CSV file
+    now = datetime.utcnow().replace(tzinfo=dateutil.tz.tzutc())
+
+    # Set up timestamps such that aggregation will reduce number of samples
+    inputRows = [
+      (now + timedelta(seconds=100 * i), i + 0.599)
+      for i in xrange(10)
+    ]
+
+    with os.fdopen(csvFd, "wb") as csvFile:
+      inputString = "\n".join(
+        "{},{}".format(col1, col2) for col1, col2 in
+        [(inTimestamp.isoformat(), inValue)
+         for inTimestamp, inValue in inputRows]
+      )
+
+      _LOGGER.debug("Writing to csv file %s: %r", csvPath, inputString)
+
+      csvFile.write(inputString)
+
+
+    # Start ModelRunner
+    inputOpt = dict(
+      csv=csvPath,
+      rowOffset=0,
+      timestampIndex=0,
+      valueIndex=1,
+      datetimeFormat="%Y-%m-%dT%H:%M:%S.%f%z"
     )
 
     modelOpt = dict(

--- a/unicorn/tests/py/unit/unicorn_backend/date_time_utils_test.py
+++ b/unicorn/tests/py/unit/unicorn_backend/date_time_utils_test.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+"""Unit test of the unicorn_backend.date_time_utils module"""
+
+import unittest
+
+
+from unicorn_backend import date_time_utils
+
+
+class DateTimeUtilsTestCase(unittest.TestCase):
+
+  # Each element is a three-tuple: format, input, result of datetime.isoformat
+  _GOOD_SAMPLES = [
+    #
+    # "ISO 8601"
+    #
+
+    # Format "%Y-%m-%dT%H:%M:%S.%f%z"
+
+    # Z
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123Z",
+      "2016-01-29T23:00:00.123000+00:00",
+    ),
+
+    # +HHMM
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123+0000",
+      "2016-01-29T23:00:00.123000+00:00",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123+0030",
+      "2016-01-29T23:00:00.123000+00:30",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123+1439",
+      "2016-01-29T23:00:00.123000+14:39",
+    ),
+
+    # +HH:MM
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123+00:00",
+      "2016-01-29T23:00:00.123000+00:00",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123+00:30",
+      "2016-01-29T23:00:00.123000+00:30",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123+14:39",
+      "2016-01-29T23:00:00.123000+14:39",
+    ),
+
+    # -HHMM
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123-0000",
+      "2016-01-29T23:00:00.123000+00:00",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123-0030",
+      "2016-01-29T23:00:00.123000-00:30",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123-1439",
+      "2016-01-29T23:00:00.123000-14:39",
+    ),
+
+    # -HH:MM
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123-00:00",
+      "2016-01-29T23:00:00.123000+00:00",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123-00:30",
+      "2016-01-29T23:00:00.123000-00:30",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123-14:39",
+      "2016-01-29T23:00:00.123000-14:39",
+    ),
+
+    # -HH
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123-00",
+      "2016-01-29T23:00:00.123000+00:00",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.123-14",
+      "2016-01-29T23:00:00.123000-14:00",
+    ),
+
+    # Experiment with fractions
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.0123-14",
+      "2016-01-29T23:00:00.012300-14:00",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.01230-14",
+      "2016-01-29T23:00:00.012300-14:00",
+    ),
+
+    (
+      "%Y-%m-%dT%H:%M:%S.%f%z",
+      "2016-01-29T23:00:00.0-14",
+      "2016-01-29T23:00:00-14:00",
+    ),
+
+
+    # Format "%Y-%m-%dT%H:%M:%S.%f"
+    (
+      "%Y-%m-%dT%H:%M:%S.%f",
+      "2016-01-29T23:00:00.1",
+      "2016-01-29T23:00:00.100000",
+    ),
+
+
+    # Format "%Y-%m-%dT%H:%M:%S%z"
+    (
+      "%Y-%m-%dT%H:%M:%S%z",
+      "2016-01-29T23:00:00-08",
+      "2016-01-29T23:00:00-08:00",
+    ),
+
+
+    # Format "%Y-%m-%dT%H:%M:%S"
+    (
+      "%Y-%m-%dT%H:%M:%S",
+      "2016-01-29T23:00:00",
+      "2016-01-29T23:00:00",
+    ),
+
+
+    # Format "%Y-%m-%dT%H:%M%z"
+    (
+      "%Y-%m-%dT%H:%M%z",
+      "2016-01-29T23:00-08",
+      "2016-01-29T23:00:00-08:00",
+    ),
+
+
+    # Format "%Y-%m-%dT%H:%M"
+    (
+      "%Y-%m-%dT%H:%M",
+      "2016-01-29T23:00",
+      "2016-01-29T23:00:00",
+    ),
+
+
+    #
+    # "ISO 8601 no T"
+    #
+
+
+    (
+      "%Y-%m-%d %H:%M:%S.%f%z",
+      "2016-01-29 23:00:00.123+0800",
+      "2016-01-29T23:00:00.123000+08:00",
+    ),
+
+
+    # Format "%Y-%m-%d %H:%M:%S.%f"
+    (
+      "%Y-%m-%d %H:%M:%S.%f",
+      "2016-01-29 23:00:00.1",
+      "2016-01-29T23:00:00.100000",
+    ),
+
+
+    # Format "%Y-%m-%d %H:%M:%S%z"
+    (
+      "%Y-%m-%d %H:%M:%S%z",
+      "2016-01-29 23:00:00-08",
+      "2016-01-29T23:00:00-08:00",
+    ),
+
+
+    # Format "%Y-%m-%d %H:%M:%S"
+    (
+      "%Y-%m-%d %H:%M:%S",
+      "2016-01-29 23:00:00",
+      "2016-01-29T23:00:00",
+    ),
+
+
+    # Format "%Y-%m-%d %H:%M%z"
+    (
+      "%Y-%m-%d %H:%M%z",
+      "2016-01-29 23:00-08",
+      "2016-01-29T23:00:00-08:00",
+    ),
+
+
+    # Format "%Y-%m-%d %H:%M"
+    (
+      "%Y-%m-%d %H:%M",
+      "2016-01-29 23:00",
+      "2016-01-29T23:00:00",
+    ),
+
+
+    #
+    # "US Date, 24h time"
+    #
+
+    # Format "%m-%d-%Y %H:%M:%S.%f"
+    (
+      "%m-%d-%Y %H:%M:%S.%f",
+      "01-29-2016 23:00:00.1",
+      "2016-01-29T23:00:00.100000",
+    ),
+
+    # Format "%m-%d-%Y %H:%M:%S"
+    (
+      "%m-%d-%Y %H:%M:%S",
+      "01-29-2016 23:00:00",
+      "2016-01-29T23:00:00",
+    ),
+
+    # Format "%m-%d-%Y %H:%M"
+    (
+      "%m-%d-%Y %H:%M",
+      "01-29-2016 23:00",
+      "2016-01-29T23:00:00",
+    ),
+
+
+    #
+    # "US Date, no time"
+    #
+
+    # Format "%m-%d-%Y"
+    (
+      "%m-%d-%Y",
+      "01-29-2016",
+      "2016-01-29T00:00:00",
+    ),
+
+
+    # TODO: WARNING the time-only formats are problematic: datetime.strptime
+    # defaults the year component to 1900-01-01. If we parse them into
+    # datetime.time, do we even have an encoder for it in NuPIC?
+
+    #
+    # "US 12h AM/PM time only"
+    #
+
+
+    # Format "%I:%M:%S.%f %p"
+    (
+      "%I:%M:%S.%f %p",
+      "11:01:59.01 AM",
+      "1900-01-01T11:01:59.010000"
+    ),
+
+    (
+      "%I:%M:%S.%f %p",
+      "11:01:59.01 PM",
+      "1900-01-01T23:01:59.010000"
+    ),
+
+    # Format "%I:%M:%S %p"
+    (
+      "%I:%M:%S %p",
+      "11:01:59 PM",
+      "1900-01-01T23:01:59"
+    ),
+
+    # Format "%I:%M %p"
+    (
+      "%I:%M %p",
+      "11:01 PM",
+      "1900-01-01T23:01:00"
+    ),
+
+
+    #
+    # 24h time only"
+    #
+
+    # Format "%H:%M:%S.%f"
+    (
+      "%H:%M:%S.%f",
+      "11:01:59.01",
+      "1900-01-01T11:01:59.010000"
+    ),
+
+    (
+      "%H:%M:%S.%f",
+      "23:01:59.01",
+      "1900-01-01T23:01:59.010000"
+    ),
+
+    # Format "%H:%M:%S"
+    (
+      "%H:%M:%S",
+      "11:01:59",
+      "1900-01-01T11:01:59"
+    ),
+
+    # Format "%H:%M"
+    (
+      "%H:%M",
+      "11:01",
+      "1900-01-01T11:01:00"
+    )
+
+  ]
+
+
+  def testGoodSamples(self):
+
+    for fmt, timestamp, expectedIso in self._GOOD_SAMPLES:
+
+      try:
+        parsed = date_time_utils.parseDatetime(timestamp, fmt)
+      except (TypeError, ValueError) as exc:
+        self.fail(
+          "Failed to parse ts={!r} using fmt={!r}; exc={!r}".format(
+            timestamp, fmt, exc))
+
+      try:
+        isoEncoded = parsed.isoformat()
+      except ValueError as exc:
+        self.fail(
+          "Failed to isoformat parsed datetime={!r}; ts={!r} using fmt={!r}; "
+          "exc={!r}".format(parsed, timestamp, fmt, exc))
+
+      self.assertEqual(
+        isoEncoded, expectedIso,
+        msg=(
+          "ISO result {!r} didn't match expected {!r}; ts={!r} using fmt={!r}"
+          .format(isoEncoded, expectedIso, timestamp, fmt)))

--- a/unicorn/tests/py/unit/unicorn_backend/model_runner_2_test.py
+++ b/unicorn/tests/py/unit/unicorn_backend/model_runner_2_test.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Copyright (C) 2016, Numenta, Inc.  Unless you have purchased from
 # Numenta, Inc. a separate commercial license for this software code, the
 # following terms and conditions apply:
 #


### PR DESCRIPTION
CC @marionleborgne, @ywcui1990 

UNI-316 Implemented date_time_utils.py in unicorn_backend for supplementing datetime.strptime() with capability to parse the timezone.

UNI-316 Implemented unit tests for date_time_utils.py in unicorn_backend.

UNI-316 Implemented integration test for model_runner_2 that feeds timestamps with timezone offset.

UNI-316 Fixed up python strftime/strptime formats in js/config/momentjs_to_datetime_strptime.json.