### PR TITLE
UNI-306 #comment Remove `npm prune` usage, it doesn't fit in automatically...

### DIFF
--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "prebuild": "npm run clean && npm install && npm run prepare",
     "build": "npm run electron:packager",
-    "check": "npm install && npm prune && npm outdated -depth 0",
+    "check": "npm install && npm outdated -depth 0",
     "clean": "npm run clean:docs && npm run clean:build && npm run clean:webpack && npm run clean:npm",
     "clean:build": "rimraf dist/ && rimraf backend/unicorn_backend/nupic/",
     "clean:db:osx": "rm -f $HOME/Library/Application\\ Support/unicorn/database/*",


### PR DESCRIPTION
UNI-306 #comment Remove `npm prune` usage, it doesn't fit in automatically during our production build (https://docs.npmjs.com/cli/prune).

https://jira.numenta.com/browse/UNI-306

@lscheinkman @marionleborgne 