### PR TITLE
UNI-311: Store param_finder results in database

### DIFF
--- a/unicorn/js/browser/actions/FileUpload.js
+++ b/unicorn/js/browser/actions/FileUpload.js
@@ -18,7 +18,7 @@
 
 import csp from 'js-csp';
 
-import {ACTIONS} from '../lib/Constants';
+import {ACTIONS, DATABASE_ERRORS} from '../lib/Constants';
 import Utils from '../../main/Utils';
 import {
   DatabaseGetError, DatabasePutError, FilesystemGetError
@@ -67,7 +67,7 @@ function getFileFromDB(options) {
   let fileId = Utils.generateFileId(file.path);
 
   databaseClient.getFile(fileId, (error, results) => {
-    if (error && (error.name !== databaseClient.ERRORS.NOT_FOUND)) {
+    if (error && (error.name !== DATABASE_ERRORS.NOT_FOUND)) {
       csp.putAsync(channel, new DatabaseGetError(error));
     } else {
       csp.putAsync(channel, results);
@@ -93,7 +93,7 @@ function getMetricsFromDB(options) {
   let fileId = Utils.generateFileId(file.path);
 
   databaseClient.getMetricsByFile(fileId, (error, results) => {
-    if (error && (error.name !== databaseClient.ERRORS.NOT_FOUND)) {
+    if (error && (error.name !== DATABASE_ERRORS.NOT_FOUND)) {
       csp.putAsync(channel, new DatabaseGetError(error));
     } else {
       csp.putAsync(channel, results);

--- a/unicorn/js/browser/actions/StartModel.js
+++ b/unicorn/js/browser/actions/StartModel.js
@@ -24,7 +24,7 @@
 
 import csp from 'js-csp';
 
-import {ACTIONS} from '../lib/Constants';
+import {ACTIONS, DATABASE_ERRORS} from '../lib/Constants';
 import ModelStore from '../stores/ModelStore';
 import SendMetricDataAction from '../actions/SendMetricData';
 import StopModelAction from '../actions/StopModel';
@@ -43,7 +43,7 @@ function getMetricFromDatabase(options) {
   let metricId = Utils.generateMetricId(model.filename, model.metric);
 
   databaseClient.getMetric(metricId, (error, results) => {
-    if (error && (error.name !== databaseClient.ERRORS.NOT_FOUND)) {
+    if (error && (error.name !== DATABASE_ERRORS.NOT_FOUND)) {
       csp.putAsync(channel, new DatabaseGetError(error));
     } else {
       csp.putAsync(channel, results);

--- a/unicorn/js/browser/lib/Constants.js
+++ b/unicorn/js/browser/lib/Constants.js
@@ -81,6 +81,16 @@ export const ACTIONS = Object.freeze({
 });
 
 /**
+ * Database Errors. Use to check database error names returned by callbacks.
+ * 	- NOT_FOUND: Record not found
+ *
+ * @type {string}
+ */
+export const DATABASE_ERRORS = {
+  NOT_FOUND: 'NotFoundError'
+};
+
+/**
  * Supported timestamp formats
  * @type {Array}
  */

--- a/unicorn/js/browser/lib/Unicorn/DatabaseClient.js
+++ b/unicorn/js/browser/lib/Unicorn/DatabaseClient.js
@@ -27,4 +27,5 @@
  */
 let remote = require('remote'); // eslint-disable-line
 let client = remote.require('./DatabaseService'); // pseduo-DBClientIPC
+
 export default client;

--- a/unicorn/js/database/schema/File.json
+++ b/unicorn/js/database/schema/File.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "id": "/File",
+  "id": "/db/File",
   "type": "object",
   "properties": {
     "uid": {
@@ -18,14 +18,14 @@
       "type": "string",
       "description": "File description"
     },
+    "timestampFieldName": {
+      "type": "string",
+      "description": "Timestamp field name"
+    },
     "timestampFormat": {
       "type": "string",
       "default": "YYYY-MM-DDTHH:mm:ss.sssZ",
       "description": "Timestamp format. Default ISO 8601"
-    },
-    "records": {
-      "type": "number",
-      "description": "Number of records"
     },
     "type": {
       "description": "Sample file from filesystem, or Uploaded file from user?",
@@ -33,5 +33,6 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "required": ["uid", "name", "filename", "type"]
 }

--- a/unicorn/js/database/schema/Metric.json
+++ b/unicorn/js/database/schema/Metric.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "id": "/Metric",
+  "id": "/db/Metric",
   "type": "object",
   "properties": {
     "uid": {
@@ -13,10 +13,6 @@
       "maxLength": 40,
       "minLength": 1
     },
-    "model_uid": {
-      "type": ["string", "null"],
-      "maxLength": 40
-    },
     "name": {
       "type": "string",
       "maxLength": 255
@@ -25,12 +21,9 @@
       "enum": ["date", "number", "string"],
       "type": "string"
     },
-    "min": {
-      "type": "number"
-    },
-    "max": {
-      "type": "number"
-    }
+    "aggregation": {"$ref": "/py/agg_opt_schema" },
+    "model_options": {"$ref": "/py/model_opt_schema" }
   },
+  "additionalProperties": false,
   "required": ["uid", "file_uid", "name", "type"]
 }

--- a/unicorn/js/database/schema/MetricData.json
+++ b/unicorn/js/database/schema/MetricData.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "id": "/MetricData",
+  "id": "/db/MetricData",
   "type": "object",
   "properties": {
     "uid": {
@@ -13,10 +13,6 @@
       "maxLength": 40,
       "minLength": 1
     },
-    "rowid": {
-      "type": "integer",
-      "default": 0
-    },
     "timestamp": {
       "type": "string",
       "format": "date-time"
@@ -24,15 +20,10 @@
     "metric_value": {
       "type": "number"
     },
-    "display_value": {
-      "type": "number"
-    },
     "anomaly_score": {
-      "type": "number"
-    },
-    "anomaly_likelihood": {
       "type": "number"
     }
   },
-  "required": ["uid", "metric_uid", "rowid", "timestamp", "metric_value", "display_value"]
+  "additionalProperties": false,
+  "required": ["uid", "metric_uid", "timestamp", "metric_value"]
 }

--- a/unicorn/js/main/DatabaseService.js
+++ b/unicorn/js/main/DatabaseService.js
@@ -450,4 +450,45 @@ DatabaseService.prototype.deleteFile = function (fileId, callback) {
   });
 }
 
+/**
+ * Update aggregation info for the given metric. Usually this value is obtained
+ * via the {@link ParamFinderService}
+ * @param {[type]} metricId  Metric to update
+ * @param {[type]} aggregation Aggregation details, usually obtained via
+ *                             {@link ParamFinderService}
+ * @param  {Function} callback called when the operation is complete,
+ *                             with a possible error argument
+ */
+DatabaseService.prototype.setMetricAggregation = function (metricId, aggregation, callback) {
+  this._metrics.get(metricId, (error, metric) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+    metric['aggregation'] = aggregation;
+    this.putMetric(metric, callback);
+  });
+}
+
+/**
+ * Update metric model parameters for the given metric. Usually this value is
+ *  obtained via the {@link ParamFinderService}
+ * @param {[type]}   metricId    Metric to update
+ * @param {[type]}   params      Model parameters to use for the given metric.
+ *                               Usually obtained via {@link ParamFinderService}
+ * @param  {Function} callback called when the operation is complete,
+ *                             with a possible error argument
+ */
+DatabaseService.prototype.setMetricModelParameters = function (metricId, params, callback) {
+  this._metrics.get(metricId, (error, metric) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+    metric['model_options'] = params;
+    this.putMetric(metric, callback);
+  });
+}
+
+
 export default DatabaseService;

--- a/unicorn/js/main/DatabaseService.js
+++ b/unicorn/js/main/DatabaseService.js
@@ -16,9 +16,7 @@
 //
 // http://numenta.org/licenses/
 
-
 // NOTE: Must be ES5 for now, Electron's `remote` does not like ES6 Classes!
-
 
 import fs from 'fs';
 import isElectronRenderer from 'is-electron-renderer';
@@ -35,7 +33,7 @@ import MetricSchema from '../database/schema/Metric.json';
 import FileSchema from '../database/schema/File.json';
 
 let location = path.join('js', 'database', 'data');
-if (! isElectronRenderer) {
+if (!isElectronRenderer) {
   try {
     // This module is only available inside 'Electron' main process
     // See https://github.com/atom/electron/blob/master/docs/api/app.md
@@ -43,9 +41,7 @@ if (! isElectronRenderer) {
     location = path.join(app.getPath('userData'), 'database');
   } catch (error) { /* no-op */ }
 }
-
 const DB_FILE_PATH = location;
-
 
 /**
  * Unicorn: DatabaseService - Respond to a DatabaseClient over IPC.
@@ -65,15 +61,7 @@ function DatabaseService(path) {
   this._files = this._root.sublevel('File');
   this._metrics = this._root.sublevel('Metric');
   this._metricData = this._root.sublevel('MetricData');
-
-  // "static" error constants
-  this.ERRORS = {
-    NOT_FOUND: 'NotFoundError'
-  };
 }
-
-
-// GETTERS
 
 /**
  * Get a single File.
@@ -167,9 +155,6 @@ DatabaseService.prototype.getMetricData = function (metricId, callback) {
     callback(null, results);
   });
 };
-
-
-// SETTERS
 
 /**
  * Put a single File to DB.
@@ -332,7 +317,6 @@ DatabaseService.prototype.close = function (callback) {
   this.levelup.db.close(callback);
 };
 
-
 /**
  * Exports model results into a CSV file
  * @param  {string}   metricId The metric from which to export results
@@ -448,5 +432,4 @@ DatabaseService.prototype.deleteFile = function (fileId, callback) {
   });
 }
 
-// EXPORTS
 export default DatabaseService;

--- a/unicorn/js/main/ModelService2.js
+++ b/unicorn/js/main/ModelService2.js
@@ -100,8 +100,6 @@ export class ModelService extends EventEmitter {
    */
   createModel(modelId, inputOpt, aggregationOpt, modelOpt) {
 
-    modelOpt['modelId'] = modelId;
-
     if (this.availableSlots() <= 0) {
       throw new MaximumConcurrencyError();
     }

--- a/unicorn/js/schemas/index.js
+++ b/unicorn/js/schemas/index.js
@@ -1,0 +1,48 @@
+// Copyright © 2016, Numenta, Inc.  Unless you have purchased from
+// Numenta, Inc. a separate commercial license for this software code, the
+// following terms and conditions apply:
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero Public License version 3 as published by the Free
+// Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero Public License for more details.
+//
+// You should have received a copy of the GNU Affero Public License along with
+// this program.  If not, see http://www.gnu.org/licenses.
+//
+// http://numenta.org/licenses/
+
+/**
+ * Module containing all JSON schemas used by Unicorn.
+ *
+ * - Database Schemas
+ * 	- DBFileSchema: Represents `File` in the database
+ * 	- DBMetricSchema: Represents `Metric` in the database
+ * 	- DBMetricDataSchema: Represents 'MetricData' in the database
+ *
+ * - Model Runner Schemas
+ * 	- MRAggOptSchema: `--agg` command-line option object passed to ModelRunner; describes the aggregation
+ * 	- MRModelOptSchema: `--model` command-line option object passed to ModelRunner
+ * 	- MRInputOptSchema: `--input` command-line option object passed to ModelRunner
+ *
+ * - Param Finder Schemas:
+ * 	- PFInputSchema: param_finder input argument option
+ * 	- PFOutputSchema: param_finder output results 
+ */
+import DBMetricDataSchema from '../database/schema/MetricData.json';
+import DBMetricSchema from '../database/schema/Metric.json';
+import DBFileSchema from '../database/schema/File.json';
+
+import MRAggregationSchema from '../../py/unicorn_backend/agg_opt_schema.json';
+import MRModelSchema from '../../py/unicorn_backend/model_opt_schema.json';
+import MRInputSchema from '../../py/unicorn_backend/input_opt_schema.json';
+
+import PFInputSchema from '../../py/unicorn_backend/input_opt_schema_param_finder.json';
+import PFOutputSchema from '../../py/unicorn_backend/param_finder_output_schema.json';
+
+export {DBFileSchema, DBMetricSchema, DBMetricDataSchema,
+        MRAggregationSchema, MRModelSchema, MRInputSchema,
+        PFInputSchema, PFOutputSchema};

--- a/unicorn/py/unicorn_backend/agg_opt_schema.json
+++ b/unicorn/py/unicorn_backend/agg_opt_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "http://json-schema.org/schema#",
+  "id": "/py/agg_opt_schema",
   "description": "--agg command-line option object passed to model runner; describes the aggregation",
   "type": "object",
   "additionalProperties": false,

--- a/unicorn/py/unicorn_backend/input_opt_schema.json
+++ b/unicorn/py/unicorn_backend/input_opt_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "http://json-schema.org/schema#",
+  "id": "/py/input_opt_schema",
   "description": "--input command-line option object passed to ModelRunner",
   "type": "object",
   "additionalProperties": false,

--- a/unicorn/py/unicorn_backend/input_opt_schema_param_finder.json
+++ b/unicorn/py/unicorn_backend/input_opt_schema_param_finder.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "http://json-schema.org/schema#",
+  "id": "/py/input_opt_schema_param_finder",
   "description": "--input command-line option object passed to model runner",
   "type": "object",
   "additionalProperties": false,

--- a/unicorn/py/unicorn_backend/model_opt_schema.json
+++ b/unicorn/py/unicorn_backend/model_opt_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "http://json-schema.org/schema#",
+  "id": "/py/model_opt_schema",
   "description": "--model command-line option object passed to model runner",
   "type": "object",
   "additionalProperties": false,

--- a/unicorn/py/unicorn_backend/model_opt_schema.json
+++ b/unicorn/py/unicorn_backend/model_opt_schema.json
@@ -7,7 +7,7 @@
     "modelId": {
       "description": "The model id; ModelRunner uses the model id for logging",
       "type": "string",
-      "required": true
+      "required": false
     },
     "modelConfig": {
       "description": "OPF Model Configuration parameters (JSON object) for passing to the OPF `ModelFactory.create()` method as the `modelConfig` parameter.",

--- a/unicorn/py/unicorn_backend/model_runner_2.py
+++ b/unicorn/py/unicorn_backend/model_runner_2.py
@@ -35,7 +35,6 @@ released)
 """
 from argparse import ArgumentParser
 import csv
-from datetime import datetime
 import json
 import logging
 import os
@@ -51,7 +50,7 @@ from nupic.data import fieldmeta
 from nupic.data import record_stream
 from nupic.frameworks.opf.modelfactory import ModelFactory
 
-from unicorn_backend import date_time_utils
+import date_time_utils
 
 
 

--- a/unicorn/py/unicorn_backend/model_runner_2.py
+++ b/unicorn/py/unicorn_backend/model_runner_2.py
@@ -192,7 +192,7 @@ class _ModelRunner(object):
     :param inputFileObj: A file-like object that contains input metric data
     :param dict inputSpec: Input data specification per input_opt_schema.json
     :param dict aggSpec: Optional aggregation specification per
-      agg_otp_schema.json or None if no aggregation is requested
+      agg_opt_schema.json or None if no aggregation is requested
     :param dict modelSpec: Model specification per model_opt_schema.json
     """
     self._inputSpec = inputSpec
@@ -200,7 +200,11 @@ class _ModelRunner(object):
     self._aggSpec = aggSpec
 
     self._modelSpec = modelSpec
-    self._modelId = modelSpec["modelId"]
+
+    if "modelId" in modelSpec:
+      self._modelId = modelSpec["modelId"]
+    else:
+      self._modelId = "Unknown"
 
 
     inputRecordSchema = (

--- a/unicorn/py/unicorn_backend/param_finder_output_schema.json
+++ b/unicorn/py/unicorn_backend/param_finder_output_schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "/py/param_finder_output_schema",
+  "description": "Param Finder output results schema",
+  "type": "object",
+  "additionalProperties": false,
+
+  "properties": {
+    "aggInfo": {"$ref": "/py/agg_opt_schema"},
+    "modelInfo": {"$ref": "/py/model_opt_schema"}
+  }
+}

--- a/unicorn/py/unicorn_backend/stats_schema.json
+++ b/unicorn/py/unicorn_backend/stats_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "http://json-schema.org/schema#",
+  "id": "/py/stats_schema",
   "description": "--stats arg passed to the engine; used by getScalarMetricWithTimeOfDayAnomalyParams in nupic.frameworks.opf.common_models.cluster_params.",
   "type": "object",
   "additionalProperties": false,

--- a/unicorn/tests/js/unit/DatabaseService_test.js
+++ b/unicorn/tests/js/unit/DatabaseService_test.js
@@ -52,6 +52,14 @@ const EXPECTED_METRIC_WITH_MODEL = {
   model_options: MODEL_OPTIONS
 };
 
+const EXPECTED_METRIC_WITH_AGGREGATION = {
+  uid: 'file1!metric1',
+  file_uid: 'file1',
+  name: 'metric1',
+  type: 'number',
+  aggregation: AGG_OPTIONS
+};
+
 const EXPECTED_METRIC_WITH_AGG_MODEL = {
   uid: 'file1!metric1',
   file_uid: 'file1',
@@ -304,6 +312,33 @@ describe('DatabaseService:', () => {
             });
           });
         });
+      });
+    });
+    it('should update metric aggregation options for metric', (done) => {
+      // Add metric
+      service.putMetric(EXPECTED_METRIC, (error) => {
+        assert.ifError(error);
+        service.setMetricAggregation(EXPECTED_METRIC.uid, AGG_OPTIONS, (error) => {
+          assert.ifError(error);
+          service.getMetric(EXPECTED_METRIC.uid, (error, actual) => {
+            assert.deepStrictEqual(actual, EXPECTED_METRIC_WITH_AGGREGATION);
+            done();
+          });
+        });
+      });
+    });
+
+    it('should update model options for metric', (done) => {
+      // Add metric
+      service.putMetric(EXPECTED_METRIC, (error) => {
+        assert.ifError(error);
+        service.setMetricModelParameters(EXPECTED_METRIC.uid, MODEL_OPTIONS, (error) => {
+          assert.ifError(error);
+          service.getMetric(EXPECTED_METRIC.uid, (error, actual) => {
+            assert.deepStrictEqual(actual, EXPECTED_METRIC_WITH_MODEL);
+            done();
+          });
+        })
       });
     });
   });

--- a/unicorn/tests/js/unit/DatabaseService_test.js
+++ b/unicorn/tests/js/unit/DatabaseService_test.js
@@ -19,15 +19,18 @@
 
 /* eslint-disable max-len, prefer-reflect */
 
-import DatabaseService from '../../../js/main/DatabaseService';
-import FileSchema from '../../../js/database/schema/File.json';
 import fs from 'fs';
-import MetricDataSchema from '../../../js/database/schema/MetricData.json';
-import MetricSchema from '../../../js/database/schema/Metric.json';
 import os from 'os';
 import path from 'path';
+import DatabaseService from '../../../js/main/DatabaseService';
+import {
+  DBFileSchema, DBMetricSchema, DBMetricDataSchema
+} from '../../../js/schemas';
 
 const assert = require('assert');
+
+const MODEL_OPTIONS = require('./fixtures/model_runner_model.json');
+const AGG_OPTIONS = require('./fixtures/model_runner_agg.json');
 
 const EXPECTED_FILE = {
   uid: 'file1',
@@ -38,25 +41,36 @@ const EXPECTED_FILE = {
 const EXPECTED_METRIC = {
   uid: 'file1!metric1',
   file_uid: 'file1',
-  model_uid: 'file1!metric1',
+  name: 'metric1',
+  type: 'number'
+};
+const EXPECTED_METRIC_WITH_MODEL = {
+  uid: 'file1!metric1',
+  file_uid: 'file1',
   name: 'metric1',
   type: 'number',
-  min: 0,
-  max: 100
+  model_options: MODEL_OPTIONS
 };
+
+const EXPECTED_METRIC_WITH_AGG_MODEL = {
+  uid: 'file1!metric1',
+  file_uid: 'file1',
+  name: 'metric1',
+  type: 'number',
+  aggregation: AGG_OPTIONS,
+  model_options: MODEL_OPTIONS
+};
+
 const EXPECTED_METRIC_DATA = {
   uid: 'file1!metric1!1420070400',
   metric_uid: 'file1!metric1',
-  rowid: 1,
   timestamp: '2015-01-01 00:00:00Z',
   metric_value: 1,
-  display_value: 1,
-  anomaly_score: 1,
-  anomaly_likelihood: 1
+  anomaly_score: 1
 };
 
 const EXPECTED_EXPORTED_RESULTS =
-`timestamp,metric_value,anomaly_likelihood
+`timestamp,metric_value,anomaly_score
 2015-01-01 00:00:00Z,1,1
 2015-01-01 00:00:00Z,1,1
 2015-01-01 00:00:00Z,1,1
@@ -82,25 +96,33 @@ describe('DatabaseService:', () => {
     let batch = db.batch();
     db.createReadStream()
       .on('data', (value) => batch.del(value.key))
-      .on('error', (error) => assert.ifError(error))
-      .on('end', () => {
-        batch.write((error) => assert.ifError(error))
-      });
+      .on('error', assert.ifError)
+      .on('end', () => batch.write(assert.ifError));
   });
 
   describe('Schema Validation:', () => {
     it('should validate "File"', (done) => {
-      let results = service.validator.validate(EXPECTED_FILE, FileSchema);
+      let results = service.validator.validate(EXPECTED_FILE, DBFileSchema);
       assert(results.errors.length === 0, JSON.stringify(results.errors));
       done();
     });
     it('should validate "Metric"', (done) => {
-      let results = service.validator.validate(EXPECTED_METRIC, MetricSchema);
+      let results = service.validator.validate(EXPECTED_METRIC, DBMetricSchema);
+      assert(results.errors.length === 0, JSON.stringify(results.errors));
+      done();
+    });
+    it('should validate "Metric" with model', (done) => {
+      let results = service.validator.validate(EXPECTED_METRIC_WITH_MODEL, DBMetricSchema);
+      assert(results.errors.length === 0, JSON.stringify(results.errors));
+      done();
+    });
+    it('should validate "Metric" with aggregation and model', (done) => {
+      let results = service.validator.validate(EXPECTED_METRIC_WITH_AGG_MODEL, DBMetricSchema);
       assert(results.errors.length === 0, JSON.stringify(results.errors));
       done();
     });
     it('should validate "MetricData"', (done) => {
-      let results = service.validator.validate(EXPECTED_METRIC_DATA, MetricDataSchema);
+      let results = service.validator.validate(EXPECTED_METRIC_DATA, DBMetricDataSchema);
       assert(results.errors.length === 0, JSON.stringify(results.errors));
       done();
     });
@@ -224,8 +246,8 @@ describe('DatabaseService:', () => {
         `${EXPECTED_METRIC.uid}!1420070401`,
         `${EXPECTED_METRIC.uid}!1420070402`,
         `${EXPECTED_METRIC.uid}!1420070403`
-      ], (uid, idx) => {
-        return Object.assign({}, EXPECTED_METRIC_DATA, {uid, rowid: idx});
+      ], (uid) => {
+        return Object.assign({}, EXPECTED_METRIC_DATA, {uid});
       });
 
       // Add metric
@@ -259,8 +281,8 @@ describe('DatabaseService:', () => {
         `${EXPECTED_METRIC.uid}!1420070401`,
         `${EXPECTED_METRIC.uid}!1420070402`,
         `${EXPECTED_METRIC.uid}!1420070403`
-      ], (uid, idx) => {
-        return Object.assign({}, EXPECTED_METRIC_DATA, {uid, rowid: idx});
+      ], (uid) => {
+        return Object.assign({}, EXPECTED_METRIC_DATA, {uid});
       });
 
       // Add metric
@@ -318,8 +340,8 @@ describe('DatabaseService:', () => {
         `${EXPECTED_METRIC_DATA.metric_uid}!1420070400`,
         `${EXPECTED_METRIC_DATA.metric_uid}!1420070401`,
         `${EXPECTED_METRIC_DATA.metric_uid}!1420070402`
-      ], (uid, idx) => {
-        return Object.assign({}, EXPECTED_METRIC_DATA, {uid, rowid: idx});
+      ], (uid) => {
+        return Object.assign({}, EXPECTED_METRIC_DATA, {uid});
       });
       service.putMetricDataBatch(batch, (error) => {
         assert.ifError(error);
@@ -340,8 +362,8 @@ describe('DatabaseService:', () => {
         `${EXPECTED_METRIC_DATA.metric_uid}!1420070401`,
         `${EXPECTED_METRIC_DATA.metric_uid}!1420070402`,
         `${EXPECTED_METRIC_DATA.metric_uid}!1420070403`
-      ], (uid, idx) => {
-        return Object.assign({}, EXPECTED_METRIC_DATA, {uid, rowid: idx});
+      ], (uid) => {
+        return Object.assign({}, EXPECTED_METRIC_DATA, {uid});
       });
       service.putMetricDataBatch(batch, (error) => {
         assert.ifError(error);
@@ -361,8 +383,8 @@ describe('DatabaseService:', () => {
         `${EXPECTED_METRIC_DATA.metric_uid}!1420070401`,
         `${EXPECTED_METRIC_DATA.metric_uid}!1420070402`,
         `${EXPECTED_METRIC_DATA.metric_uid}!1420070403`
-      ], (uid, idx) => {
-        return Object.assign({}, EXPECTED_METRIC_DATA, {uid, rowid: idx});
+      ], (uid) => {
+        return Object.assign({}, EXPECTED_METRIC_DATA, {uid});
       });
 
       // Add data


### PR DESCRIPTION
@marionleborgne this PR is changing the `Metric` schema to be compatible with the new API (03f041a) therefore it wont be fully functional until we refactor the actions related to the `model_runner` and `param_finder`.
See 3704a78 for the specific database calls and usage/tests. 