### PR TITLE
UNI-326 Use unicorn_backend.date_time_utils.parseDatetime instead of datetime.strptime in param_finder_runner.py

### DIFF
--- a/unicorn/py/unicorn_backend/model_runner_2.py
+++ b/unicorn/py/unicorn_backend/model_runner_2.py
@@ -35,7 +35,6 @@ released)
 """
 from argparse import ArgumentParser
 import csv
-from datetime import datetime
 import json
 import logging
 import os
@@ -51,7 +50,7 @@ from nupic.data import fieldmeta
 from nupic.data import record_stream
 from nupic.frameworks.opf.modelfactory import ModelFactory
 
-import date_time_utils
+from unicorn_backend import date_time_utils
 
 
 

--- a/unicorn/py/unicorn_backend/param_finder_runner.py
+++ b/unicorn/py/unicorn_backend/param_finder_runner.py
@@ -25,7 +25,6 @@ Implements Unicorn's param_finder interface.
 """
 from argparse import ArgumentParser
 import csv
-import datetime
 import json
 import logging
 import os
@@ -36,8 +35,10 @@ import traceback
 from dateutil import tz
 import validictory
 
-from param_finder import findParameters
-from param_finder import MAX_NUM_ROWS
+from unicorn_backend.param_finder import findParameters
+from unicorn_backend.param_finder import MAX_NUM_ROWS
+
+from unicorn_backend import date_time_utils
 
 g_log = logging.getLogger(__name__)
 
@@ -174,8 +175,8 @@ def _readCSVFile(fileName,
     samples = []
     numRows = 0
     for row in fileReader:
-      timestamp = datetime.datetime.strptime(row[timestampIndex],
-                                             datetimeFormat)
+      timestamp = date_time_utils.parseDatetime(row[timestampIndex],
+                                                datetimeFormat)
 
       # use utc timezone if timezone information is not provided
       if timestamp.tzinfo is None:


### PR DESCRIPTION
CC @marionleborgne @ywcui1990 

- UNI-326 Use unicorn_backend.date_time_utils.parseDatetime instead of datetime.strptime in param_finder_runner.py
- Also fix several pylint warnings concerning unused imports and relative imports.