### PR TITLE
python imports

### DIFF
--- a/unicorn/README.md
+++ b/unicorn/README.md
@@ -187,7 +187,6 @@ git clone https://github.com/numenta/numenta-apps
 cd numenta-apps/unicorn
 pip install -r py/requirements.txt
 npm install
-unset PYTHONPATH  # force usage of our custom internal Python
 ```
 
 

--- a/unicorn/py/unicorn_backend/model_runner_2.py
+++ b/unicorn/py/unicorn_backend/model_runner_2.py
@@ -41,7 +41,6 @@ import os
 import pkg_resources
 import sys
 import traceback
-
 import validictory
 
 from nupic.algorithms.anomaly_likelihood import AnomalyLikelihood
@@ -49,6 +48,10 @@ from nupic.data import aggregator
 from nupic.data import fieldmeta
 from nupic.data import record_stream
 from nupic.frameworks.opf.modelfactory import ModelFactory
+
+# Add numenta-apps/unicorn/py to the path
+py_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(py_dir)
 
 from unicorn_backend import date_time_utils
 

--- a/unicorn/py/unicorn_backend/model_runner_2.py
+++ b/unicorn/py/unicorn_backend/model_runner_2.py
@@ -51,7 +51,7 @@ from nupic.frameworks.opf.modelfactory import ModelFactory
 
 # Add numenta-apps/unicorn/py to the path
 py_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-sys.path.append(py_dir)
+sys.path.insert(0, py_dir)
 
 from unicorn_backend import date_time_utils
 

--- a/unicorn/py/unicorn_backend/param_finder_runner.py
+++ b/unicorn/py/unicorn_backend/param_finder_runner.py
@@ -31,13 +31,16 @@ import os
 import pkg_resources
 import sys
 import traceback
+import validictory
 
 from dateutil import tz
-import validictory
+
+# Add numenta-apps/unicorn/py to the path
+py_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(py_dir)
 
 from unicorn_backend.param_finder import findParameters
 from unicorn_backend.param_finder import MAX_NUM_ROWS
-
 from unicorn_backend import date_time_utils
 
 g_log = logging.getLogger(__name__)

--- a/unicorn/py/unicorn_backend/param_finder_runner.py
+++ b/unicorn/py/unicorn_backend/param_finder_runner.py
@@ -37,7 +37,7 @@ from dateutil import tz
 
 # Add numenta-apps/unicorn/py to the path
 py_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-sys.path.append(py_dir)
+sys.path.insert(0, py_dir)
 
 from unicorn_backend.param_finder import findParameters
 from unicorn_backend.param_finder import MAX_NUM_ROWS


### PR DESCRIPTION
@vitaly-krugl  @lscheinkman here is a proposed solution (for https://github.com/numenta/numenta-apps/pull/651) to avoid having relative imports while not introducing the need to alter the PYTHONPATH on the node side when we spawn the python process. 

I added a few lines to udpate the pythonpath dynamically at runtime. Let me know your thoughts on that.

cc @brev @oxtopus 