### PR TITLE
Convert services into singletons created in the `main` process only

### DIFF
--- a/unicorn/js/browser/app.js
+++ b/unicorn/js/browser/app.js
@@ -32,9 +32,9 @@ import ReactDOM from 'react-dom';
 import remote from 'remote';
 import tapEventInject from 'react-tap-event-plugin';
 
-import ConfigClient from './lib/Unicorn/ConfigClient';
-import DatabaseClient from './lib/Unicorn/DatabaseClient';
-import FileClient from './lib/Unicorn/FileClient';
+import config from './lib/Unicorn/ConfigClient';
+import databaseClient from './lib/Unicorn/DatabaseClient';
+import fileClient from './lib/Unicorn/FileClient';
 import FileDetailsStore from './stores/FileDetailsStore';
 import MetricStore from './stores/MetricStore';
 import FileStore from './stores/FileStore';
@@ -49,12 +49,9 @@ import ModelStore from './stores/ModelStore';
 import UnicornPlugin from './lib/Fluxible/UnicornPlugin';
 import Utils from '../main/Utils';
 
-const config = new ConfigClient();
 const dialog = remote.require('dialog');
 const logger = bunyan.createLogger(loggerConfig);
 
-let databaseClient = new DatabaseClient();
-let fileClient = new FileClient();
 let modelClient = new ModelClient();
 let paramFinderClient = new ParamFinderClient();
 

--- a/unicorn/js/browser/lib/Unicorn/ConfigClient.js
+++ b/unicorn/js/browser/lib/Unicorn/ConfigClient.js
@@ -25,4 +25,5 @@
  *  pseudo-library, using the magic of Electron's `remote` module.
  */
 let remote = require('remote'); // eslint-disable-line
-export default remote.require('./ConfigService'); // pseduo-ConfigClientIPC
+let client = remote.require('./ConfigService'); // Get singleton
+export default client;

--- a/unicorn/js/browser/lib/Unicorn/DatabaseClient.js
+++ b/unicorn/js/browser/lib/Unicorn/DatabaseClient.js
@@ -26,7 +26,6 @@
  *  `remote` module.
  */
 let remote = require('remote'); // eslint-disable-line
-let client = remote.require('./DatabaseService'); // pseduo-DBClientIPC
 
 /**
  * Get all metrics from the database as a {@link Promise}
@@ -81,4 +80,5 @@ export function promiseSaveFilesIntoDB(db, files) {
   });
 }
 
+let client = remote.require('./DatabaseService').default; // Get singleton
 export default client;

--- a/unicorn/js/browser/lib/Unicorn/FileClient.js
+++ b/unicorn/js/browser/lib/Unicorn/FileClient.js
@@ -25,7 +25,6 @@
  *  pseudo-library, using the magic of Electron's `remote` module.
  */
 let remote = require('remote'); // eslint-disable-line
-let client = remote.require('./FileService'); // pseduo-FileClientIPC
 
 /**
  * Get all metrics from the given files as a {@link Promise}
@@ -69,4 +68,5 @@ export function promiseLoadSampleFilesFromDisk(fs) {
   });
 }
 
+let client = remote.require('./FileService'); // Get singleton
 export default client;

--- a/unicorn/js/main/ConfigService.js
+++ b/unicorn/js/main/ConfigService.js
@@ -39,7 +39,7 @@ const Defaults = {
  *  NOTE: Must be ES5 for now, Electron's `remote` does not like ES6 Classes!
  * @return {Object} - Configuration data handler object
  */
-function ConfigService() {
+function createConfigService() {
   const config = nconf.env().argv().defaults(Defaults);
 
   config.file(path.join(CONFIG_PATH, CONFIG_FILE));
@@ -52,5 +52,6 @@ function ConfigService() {
 }
 
 
-// EXPORTS
-module.exports = ConfigService;
+// Returns singleton
+const INSTANCE = createConfigService();
+export default INSTANCE;

--- a/unicorn/js/main/DatabaseService.js
+++ b/unicorn/js/main/DatabaseService.js
@@ -19,6 +19,7 @@
 // NOTE: Must be ES5 for now, Electron's `remote` does not like ES6 Classes!
 
 import fs from 'fs';
+import os from 'os';
 import isElectronRenderer from 'is-electron-renderer';
 import json2csv from 'json2csv-stream';
 import leveldown from 'leveldown';
@@ -58,7 +59,7 @@ const SCHEMAS = [
  * @return {string} Full path name
  */
 function _getDefaultDatabaseLocation() {
-  let location = path.join('js', 'database', 'data');
+  let location = path.join(os.tmpdir());
   if (!isElectronRenderer) {
     try {
       // This module is only available inside 'Electron' main process
@@ -75,7 +76,7 @@ function _getDefaultDatabaseLocation() {
  *  Meant for heavy persistence.
  * @param {string} [path] - Database location path (optional)
  */
-function DatabaseService(path) {
+export function DatabaseService(path) {
   let location = path || _getDefaultDatabaseLocation();
 
   // Configure schema validator
@@ -618,4 +619,6 @@ DatabaseService.prototype.setMetricInputOptions = function (metricId, options, c
   });
 }
 
-export default DatabaseService;
+// Returns singleton
+const INSTANCE = new DatabaseService();
+export default INSTANCE;

--- a/unicorn/js/main/FileService.js
+++ b/unicorn/js/main/FileService.js
@@ -340,5 +340,6 @@ FileService.prototype.getStatistics = function (filename, options, callback) {
 };
 
 
-// EXPORTS
-export default FileService;
+// Returns singleton
+const INSTANCE = new FileService();
+export default INSTANCE;

--- a/unicorn/js/main/index.js
+++ b/unicorn/js/main/index.js
@@ -21,12 +21,11 @@ import {app, BrowserWindow, crashReporter, dialog, Menu} from 'electron';
 import bunyan from 'bunyan';
 import path from 'path';
 
-import Config from './ConfigService';
+import config from './ConfigService';
 import MainMenu from './MainMenu';
 import ModelServiceIPC from './ModelServiceIPC';
 import ParamFinderServiceIPC from './ParamFinderServiceIPC';
 
-const config = new Config();
 const DEV = config.get('NODE_ENV') !== 'production';
 const log = bunyan.createLogger({
   level: 'debug',  // @TODO higher for Production

--- a/unicorn/tests/js/unit/services/DatabaseService_test.js
+++ b/unicorn/tests/js/unit/services/DatabaseService_test.js
@@ -22,7 +22,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import DatabaseService from '../../../../js/main/DatabaseService';
+import {DatabaseService} from '../../../../js/main/DatabaseService';
 import {
   DBFileSchema, DBMetricSchema, DBMetricDataSchema, DBModelDataSchema
 } from '../../../../js/schemas';

--- a/unicorn/tests/js/unit/services/FileService_test.js
+++ b/unicorn/tests/js/unit/services/FileService_test.js
@@ -22,7 +22,7 @@ const assert = require('assert');
 
 import path from 'path';
 
-import FileService from '../../../../js/main/FileService';
+import service from '../../../../js/main/FileService';
 
 
 // Contents of 'fixture/file.csv'
@@ -81,12 +81,6 @@ const FILENAME_LARGE = path.resolve(__dirname, '../fixtures/rec-center-15.csv');
 
 /* eslint-disable max-nested-callbacks */
 describe('FileService', () => {
-  let service;
-
-  beforeEach(() => {
-    service = new FileService();
-  });
-
   describe('#getSampleFiles()', () => {
     it('should list sample files', (done) => {
       service.getSampleFiles((error, files) => {

--- a/unicorn/webpack.config.babel.js
+++ b/unicorn/webpack.config.babel.js
@@ -17,9 +17,8 @@
 
 import path from 'path';
 
-import Config from './js/main/ConfigService';
+import config from './js/main/ConfigService';
 
-const config = new Config();
 
 let destination = path.join(__dirname, config.get('bundle:destination'));
 let publics = path.join(__dirname, config.get('bundle:public'));


### PR DESCRIPTION
Convert `main` process services into singletons created in the `main` process and accessed via `remote` by the `renderer` process.

@marionleborgne, @brev  Please review