### PR TITLE
Install 'unicorn_backend' package into 'portable_python' module

### DIFF
--- a/unicorn/README.md
+++ b/unicorn/README.md
@@ -197,6 +197,13 @@ is already installed:
 npm install --no-optional
 ```
 
+### Unicorn backend install
+
+Execute the following command after making changes to `unicorn_backend` code:
+```shell
+npm run install:backend
+```
+
 ### Run
 
 ```shell

--- a/unicorn/js/main/ModelService.js
+++ b/unicorn/js/main/ModelService.js
@@ -21,14 +21,10 @@
 import getPortablePython from './PortablePython';
 import childProcess from 'child_process';
 import EventEmitter from 'events';
-import path from 'path';
 import system from 'os';
 import UserError from './UserError';
 
 const PYTHON_EXECUTABLE = getPortablePython();
-const MODEL_RUNNER_PATH = path.join(
-  __dirname, '..', '..', 'py', 'unicorn_backend', 'model_runner_2.py'
-);
 
 /**
  * Thrown when attempting to create more models than allowed by the system.
@@ -106,7 +102,8 @@ export class ModelService extends EventEmitter {
       throw new DuplicateIDError();
     }
 
-    const params = [MODEL_RUNNER_PATH,
+    const params = [
+      '-m', 'unicorn_backend.model_runner_2',
       '--input', JSON.stringify(inputOpt),
       '--agg', JSON.stringify(aggregationOpt),
       '--model', JSON.stringify(modelOpt)

--- a/unicorn/js/main/ParamFinderService.js
+++ b/unicorn/js/main/ParamFinderService.js
@@ -21,13 +21,9 @@
 import getPortablePython from './PortablePython';
 import childProcess from 'child_process';
 import EventEmitter from 'events';
-import path from 'path';
 import UserError from './UserError';
 
 const PYTHON_EXECUTABLE = getPortablePython();
-const PARAM_FINDER_PATH = path.join(
-  __dirname, '..', '..', 'py', 'unicorn_backend', 'param_finder_runner.py'
-);
 
 /**
  * Thrown when attempting to create more than 1 param finder per metric
@@ -95,7 +91,8 @@ export class ParamFinderService extends EventEmitter {
       throw new DuplicateIDError();
     }
 
-    const params = [PARAM_FINDER_PATH,
+    const params = [
+      '-m', 'unicorn_backend.param_finder_runner',
       '--input', JSON.stringify(inputOpt)
     ];
     const child = childProcess.spawn(PYTHON_EXECUTABLE, params);

--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -42,6 +42,8 @@
     "lint": "eslint --ext=js --ext=jsx js/ tests/js/",
     "prepare": "npm run lint && webpack",
     "pretest": "npm run prepare",
+    "install:backend": "python py/setup.py install",
+    "postinstall": "npm run install:backend",
     "test": "npm run test:unit && npm run test:integration",
     "test:integration": "mocha --opts tests/js/mocha.opts tests/js/integration",
     "pretest:pipeline": "npm run prepare",

--- a/unicorn/py/MANIFEST.in
+++ b/unicorn/py/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include unicorn_backend *.json

--- a/unicorn/py/requirements.txt
+++ b/unicorn/py/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil==2.1
 validictory==0.9.1
 
-# NuPIC HTM
-nupic==0.3.6
+# NuPIC HTM. Use version installed with 'portable_python'
+nupic

--- a/unicorn/py/setup.py
+++ b/unicorn/py/setup.py
@@ -10,8 +10,8 @@ installRequires = []
 dependencyLinks = []
 
 
-
-with open("requirements.txt", "r") as reqfile:
+requirements = os.path.join(os.path.dirname(__file__), "requirements.txt")
+with open(requirements, "r") as reqfile:
   for line in reqfile:
     line = line.strip()
     (link, _, package) = line.rpartition("#egg=")
@@ -56,8 +56,7 @@ class PyTest(TestCommand):
       os.chdir(cwd)
     sys.exit(errno)
 
-
-
+os.chdir(os.path.dirname(__file__))
 setup(
   name = "unicorn_backend",
   description = "Unicorn backend",


### PR DESCRIPTION
This PR should replace #662 and #663.
Now `unicorn_backend` package is installed automatically into `portable_python` node module

If you have `portable_python` already installed you can use `npm run install:backend` to install the `unicorn_backend` package only.

Please review
@vitaly-krugl @marionleborgne @oxtopus 

