### PR TITLE
Fix installation using new ci build

### DIFF
--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -137,7 +137,7 @@
     "webpack": "1.12.14"
   },
   "optionalDependencies": {
-    "portable_python_darwin": "https://ci.numenta.com/browse/UN-UN/latestSuccessful/artifact/BOX/portable_python/portable_python.tar.gz",
-    "portable_python_win32": "https://ci.numenta.com/browse/UN-UN/latestSuccessful/artifact/JOB1/portable_python/portable_python.tar.gz"
+    "portable_python_darwin": "https://ci.numenta.com/artifact/UN-UN/shared/build-latestSuccessful/portable_python-darwin/portable_python.tar.gz",
+    "portable_python_win32": "https://ci.numenta.com/artifact/UN-UN/shared/build-latestSuccessful/portable_python-win64/portable_python.tar.gz"
   }
 }


### PR DESCRIPTION
@marionleborgne, @brev 

This should fix the installation issues we had with `npm install` for `portable_python`.

CC: @oxtopus 