### PR TITLE
Update uwsgi req for imbu on osx 10.11

### DIFF
--- a/imbu/requirements.txt
+++ b/imbu/requirements.txt
@@ -10,5 +10,5 @@ pytest==2.5.1
 pytest-cov==1.6
 pytest-xdist==1.8
 supervisor==3.1.3
-uwsgi==2.0.4
+uwsgi==2.0.12
 web.py==0.37


### PR DESCRIPTION
@lscheinkman this allows me to install imbu on El Capitan. Is there a reason we specify v2.0.4?