### PR TITLE
Reduce taurus nginx and uwsgi listen queue sizes to 128 to match the default net.core.somaxconn on linux.

### DIFF
--- a/taurus/conf/nginx-taurus.conf
+++ b/taurus/conf/nginx-taurus.conf
@@ -1,6 +1,6 @@
 
 events {
-    worker_connections 1024;
+    worker_connections 128;
 }
 
 http {

--- a/taurus/conf/supervisord.conf
+++ b/taurus/conf/supervisord.conf
@@ -46,7 +46,7 @@ serverurl=http://:
 
 ;*************** TAURUS-API **************
 [program:taurus-api]
-command=uwsgi --enable-threads --socket 0.0.0.0:19002 --master --vacuum --idle 300 --processes 8 --threads 4 --listen 1024 --module taurus.engine.webservices.webapp
+command=uwsgi --enable-threads --socket 0.0.0.0:19002 --master --vacuum --idle 300 --processes 8 --threads 4 --listen 128 --module taurus.engine.webservices.webapp
 process_name=%(program_name)s_%(process_num)02d
 directory=%(here)s/..
 stdout_logfile_maxbytes=50MB


### PR DESCRIPTION
CC @oxtopus 

This PR is in response to nginx failure issue reported on nupic@lists.numenta.org by vannroath 