### PR TITLE
Add code coverage reporting

### DIFF
--- a/unicorn/.gitignore
+++ b/unicorn/.gitignore
@@ -1,13 +1,15 @@
 *.egg
 *.egg-info
 *.log
+
 .tags_swap
 tags
+
 build/
+coverage/
 dist/
-nupic/
 js/browser/assets/bundle/
 js/docs/
-logs/
 node_modules/
+nupic/
 Unicorn-darwin-x64/

--- a/unicorn/.istanbul.yml
+++ b/unicorn/.istanbul.yml
@@ -1,0 +1,3 @@
+instrumentation:
+  root: js/
+  extensions: ['.js', '.jsx']

--- a/unicorn/.istanbul.yml
+++ b/unicorn/.istanbul.yml
@@ -1,3 +1,5 @@
 instrumentation:
-  root: js/
-  extensions: ['.js', '.jsx']
+  root: js
+  extensions:
+    - .jsx
+    - .js

--- a/unicorn/README.md
+++ b/unicorn/README.md
@@ -36,6 +36,7 @@ goal to demo to the user.
 ├── DEPENDENCIES.md         # Module dependency overview file
 ├── LICENSE.txt             # Dual: Commercial and AGPLv3
 ├── README.md               # This file. A project overview.
+├── coverage/               # JS Unit+Integration test coverage output (!git)
 ├── js/                     # Frontend+GUI that exposes NuPIC HTM models to User
 │   ├── assets/             # System/native-level assets, images, icons, etc.
 │   ├── browser/            # JS+HTML+CSS as GUI in electron's Renderer Process
@@ -259,10 +260,12 @@ Here are the `npm` scripts available via `npm run <script-name>`. Please see
   * `test:integration`: Run all JS integration tests
   * `test:unit`: Run all JS unit tests
   * `test:functional`: Run all JS functional tests
-* `test:pipeline`:Run all JS tests using pipeline options. See
+* `test:pipeline`: Run all JS tests using pipeline options. See
   [mocha.opts](tests/js/mocha.pipeline.opts)
   * `test:pipeline:integration`:  Run all JS integration tests
   * `test:pipeline:unit`: Run all JS unit tests
+* `test:coverage`: Run test coverage on all JS unit+integration tests, and
+  open reports when done in browser.
 
 ### Problems?
 
@@ -319,6 +322,16 @@ with a different set of options
 npm run test:pipeline               # pipeline all
 npm run test:pipeline:unit          # pipeline unit tests only
 npm run test:pipeline:integration   # pipeline integration tests only
+```
+
+### Test Coverage
+
+Use the following to generate JS Unit and Integration test code coverage
+results, build the reports, and open them in browser for display. Output
+data is in the untracked `./coverage/` directory.
+
+```shell
+npm run test:coverage     # run code coverage on js unit+int tests
 ```
 
 ### Common Test Problems

--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -25,6 +25,7 @@
     "build": "npm run electron:packager",
     "clean": "npm install rimraf && npm run clean:docs && npm run clean:build && npm run clean:webpack && npm run clean:npm",
     "clean:build": "rimraf dist/ && rimraf backend/unicorn_backend/nupic/",
+    "clean:coverage": "rimraf coverage/",
     "clean:db:osx": "rm -rf $HOME/Library/Application\\ Support/HTM\\ Studio/*",
     "clean:docs": "rimraf js/docs/",
     "clean:npm": "rimraf node_modules/ && npm cache clean",
@@ -45,6 +46,9 @@
     "install:backend": "python py/setup.py install",
     "postinstall": "npm run install:backend",
     "test": "npm run test:unit && npm run test:integration",
+    "pretest:coverage": "npm run clean:coverage && npm run clean:docs && npm run clean:webpack",
+    "test:coverage": "babel-node `npm bin`/isparta cover --include-all-sources _mocha -- --opts tests/js/mocha.opts tests/js/{unit,integration}",
+    "posttest:coverage": "open-url file://${PWD}/coverage/lcov-report/index.html",
     "test:integration": "mocha --opts tests/js/mocha.opts tests/js/integration",
     "pretest:pipeline": "npm run prepare",
     "test:pipeline": "npm run test:pipeline:unit && npm run test:pipeline:integration",
@@ -109,6 +113,7 @@
     "roboto-fontface": "0.4.5"
   },
   "devDependencies": {
+    "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-eslint": "4.1.8",
     "babel-loader": "6.2.4",
@@ -128,6 +133,7 @@
     "eslint": "1.10.3",
     "eslint-plugin-react": "3.16.1",
     "file-loader": "0.8.5",
+    "isparta": "4.0.0",
     "json-loader": "0.5.4",
     "lev": "3.3.1",
     "mocha": "2.4.5",

--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -47,7 +47,7 @@
     "postinstall": "npm run install:backend",
     "test": "npm run test:unit && npm run test:integration",
     "pretest:coverage": "npm run clean:coverage && npm run clean:docs && npm run clean:webpack",
-    "test:coverage": "babel-node `npm bin`/isparta cover --include-all-sources _mocha -- --opts tests/js/mocha.opts tests/js/{unit,integration}",
+    "test:coverage": "babel-node `npm bin`/isparta cover --verbose --include '**/*.jsx' --include '**/*.js' --include-all-sources _mocha -- --opts tests/js/mocha.opts tests/js/{unit,integration}",
     "posttest:coverage": "open-url file://${PWD}/coverage/lcov-report/index.html",
     "test:integration": "mocha --opts tests/js/mocha.opts tests/js/integration",
     "pretest:pipeline": "npm run prepare",

--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -47,7 +47,7 @@
     "postinstall": "npm run install:backend",
     "test": "npm run test:unit && npm run test:integration",
     "pretest:coverage": "npm run clean:coverage && npm run clean:docs && npm run clean:webpack",
-    "test:coverage": "babel-node `npm bin`/isparta cover --verbose --include '**/*.jsx' --include '**/*.js' --include-all-sources _mocha -- --opts tests/js/mocha.opts tests/js/{unit,integration}",
+    "test:coverage": "babel-node `npm bin`/isparta cover --include '**/*.jsx' --include '**/*.js' --include-all-sources _mocha -- --opts tests/js/mocha.opts tests/js/{unit,integration}",
     "posttest:coverage": "open-url file://${PWD}/coverage/lcov-report/index.html",
     "test:integration": "mocha --opts tests/js/mocha.opts tests/js/integration",
     "pretest:pipeline": "npm run prepare",


### PR DESCRIPTION
Add code coverage reporting for JS unit and integration tests, .js and .jsx files.

`npm run test:coverage`

Ready for review @lscheinkman @marionleborgne 