### PR TITLE
Fix failure of XigniteStockAgentTestCase.testForwardAfterHours unit test when executed while metric collectors are in hot_standby mode

### DIFF
--- a/taurus.metric_collectors/tests/unit/xignite_stock_agent_test.py
+++ b/taurus.metric_collectors/tests/unit/xignite_stock_agent_test.py
@@ -30,6 +30,7 @@ import urlparse
 
 import pytz
 
+from taurus import metric_collectors
 from taurus.metric_collectors import logging_support
 from taurus.metric_collectors.xignite import xignite_stock_agent
 
@@ -524,7 +525,9 @@ class XigniteStockAgentTestCase(unittest.TestCase):
       stockExchange="NASDAQ",
       sampleKey="Volume")
 
-    xignite_stock_agent.forward((msft,), data, security)
+    with patch.object(xignite_stock_agent, "g_opMode",
+                      new=metric_collectors.ApplicationConfig.OP_MODE_ACTIVE):
+      xignite_stock_agent.forward((msft,), data, security)
 
     self.assertEqual(
       collectorsdb.engineFactory.return_value.execute.call_count,
@@ -654,3 +657,8 @@ class XigniteStockAgentTestCase(unittest.TestCase):
        call(metricName="XIGNITE.MSFT.VOLUME",
             value=492621,
             epochTimestamp=1421332500.0)])
+
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
CC @scottpurdy @oxtopus 

This happened after the graceful-update-testing-taurus-servers pipeline ran and failed, leaving the metric collectors in hot standby mode.