### PR TITLE
Fix osx taurus install failure of uwsgi 2.0.4 by switching to uwsgi 2.0.12

### DIFF
--- a/taurus/requirements.txt
+++ b/taurus/requirements.txt
@@ -2,7 +2,7 @@ boto==2.38.0
 sqlalchemy==0.9.4
 mysql-python==1.2.5
 supervisor==3.1.3
-uwsgi==2.0.4
+uwsgi==2.0.12
 alembic==0.6.7
 web.py==0.37
 msgpack-python==0.3.0


### PR DESCRIPTION
CC @scottpurdy @oxtopus 

Switching to uwsgi 2.0.12. The old 2.0.4 build fails on OS X 10.11 (undeclared SOL_TCP compiler error). See https://github.com/unbit/uwsgi/issues/1056.

I validated this change via http://jenkins-master.numenta.com/job/refresh-taurus-servers/251/.

Note that I still get a failure with 2.0.12 on OS X 10.11.4 when installging uwsgi indirectly via `python setup.py develop --user` from taurus (unable to write to a python system directory). However, `pip install uwsgi=2.0.12 --user` succeeds.