### PR TITLE
UNI-409 Improve peak detection algorithm in paramFinder

### DIFF
--- a/unicorn/py/unicorn_backend/param_finder.py
+++ b/unicorn/py/unicorn_backend/param_finder.py
@@ -253,9 +253,7 @@ def findParameters(samples):
   (useTimeOfDay, useDayOfWeek) = _determineEncoderTypes(cwtVar, timeScale)
 
   # decide the aggregation function ("mean" or "sum")
-  aggFunc = _getAggregationFunction(medianSamplingInterval,
-                                    medianAbsoluteDevSamplingInterval,
-                                    _AGGREGATION_WINDOW_THRESH)
+  aggFunc = _getAggregationFunction(values)
 
   return {
     "aggInfo": _getAggInfo(medianSamplingInterval,
@@ -553,30 +551,19 @@ def _determineEncoderTypes(cwtVar, timeScale):
 
 
 
-def _getAggregationFunction(medianSamplingInterval,
-                            medianAbsoluteDevSamplingInterval,
-                            aggregationFuncThresh):
+def _getAggregationFunction(values):
   """
   Return the aggregation function type:
     ("sum" for transactional data types
      "mean" for non-transactional data types)
 
-  The data type is determined via a data type indicator, defined as the
-  ratio between median absolute deviation and median of the sampling interval.
-  @param medianSamplingInterval, numpy timedelta64 in unit of seconds
-
-  @param medianAbsoluteDev (timedelta64) the median absolute deviation of
-          sampling interval
-
-  @param aggregationFuncThresh (float) a positive number indication the
-        threshold between transactional and non-transactional data types
-        A higher threshold will lead to a bias towards non-transactional data
+  Use "sum" for binary transactional data, and "mean" otherwise
+  @param values, numpy data values
 
   @return aggFunc (string) "sum" or "mean"
   """
-  dataTypeIndicator = (medianAbsoluteDevSamplingInterval /
-                       medianSamplingInterval)
-  if dataTypeIndicator > aggregationFuncThresh:
+
+  if len(numpy.unique(values)) <= 2:
     aggFunc = "sum"  # "transactional"
   else:
     aggFunc = "mean"  # "non-transactional"

--- a/unicorn/py/unicorn_backend/param_finder.py
+++ b/unicorn/py/unicorn_backend/param_finder.py
@@ -42,10 +42,11 @@ _CORRELATION_MODE_FULL = 2
 
 _AGGREGATION_WINDOW_THRESH = 0.03
 
+_ONE_DAY_IN_SEC = 86400.0
+_ONE_WEEK_IN_SEC = 604800.0
+
 # Maximum time scale for wavelet analysis. The longer time scale will be ignored
 # in unit of seconds
-_ONE_DAY_IN_SEC = 86400
-_ONE_WEEK_IN_SEC = 604800
 MAX_WAVELET_TIME_WINDOW_SEC = _ONE_WEEK_IN_SEC * 20
 
 # Maximum number of rows param_finder will process
@@ -541,7 +542,7 @@ def _determineEncoderTypes(cwtVar, timeScale):
           and cwtVarAtDayPeriod > localMaxValue * 0.5):
         useTimeOfDay = True
 
-      if DISABLE_DAY_OF_WEEK_ENCODER is False:
+      if not DISABLE_DAY_OF_WEEK_ENCODER:
         if (timeScale[leftLocalMin] < _ONE_WEEK_IN_SEC <
             timeScale[rightLocalMin] and
             cwtVarAtWeekPeriod > localMaxValue * 0.5):


### PR DESCRIPTION
Summary

* Improve peak detection algorithm in paramFinder. The paramFinder now recommends to use timeOfDay encoder for VonAnalytics data. 
* Implement a long (20 weeks) cut off on time scale for wavelet analysis
* 	Always use 'mean' aggregation unless for binary data
* Update paramFinder tests