### PR TITLE
UNI-334: Fix daylight savings. Assume UTC.

### DIFF
--- a/unicorn/app/browser/components/Chart.jsx
+++ b/unicorn/app/browser/components/Chart.jsx
@@ -16,7 +16,6 @@
 // http://numenta.org/licenses/
 
 import CircularProgress from 'material-ui/lib/circular-progress';
-import moment from 'moment';
 import Paper from 'material-ui/lib/paper';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -123,8 +122,8 @@ export default class Chart extends React.Component {
     let {data, metaData, options} = this.props;
     let {metric, model} = metaData;
     let element = ReactDOM.findDOMNode(this.refs[`chart-${model.modelId}`]);
-    let first = moment(data[0][DATA_INDEX_TIME]).valueOf();
-    let second = moment(data[1][DATA_INDEX_TIME]).valueOf();
+    let first = data[0][DATA_INDEX_TIME].getTime();
+    let second = data[1][DATA_INDEX_TIME].getTime();
     let unit = second - first; // each datapoint
     let rangeWidth = unit * this._displayPointCount;
     let rangeEl;
@@ -156,7 +155,7 @@ export default class Chart extends React.Component {
     let {data, metaData, options} = this.props;
     let {model} = metaData;
     let modelIndex = Math.abs(model.dataSize - 1);
-    let first = moment(data[0][DATA_INDEX_TIME]).valueOf();
+    let first = data[0][DATA_INDEX_TIME].getTime();
     let [rangeMin, rangeMax] = this._chartRange;
     let rangeWidth = rangeMax - rangeMin;
     let scrollLock = false;
@@ -171,7 +170,7 @@ export default class Chart extends React.Component {
 
     // scroll along with fresh anomaly model data input.
     if (scrollLock) {
-      rangeMax = moment(data[modelIndex][DATA_INDEX_TIME]).valueOf();
+      rangeMax = data[modelIndex][DATA_INDEX_TIME].getTime();
       rangeMin = rangeMax - rangeWidth;
       if (rangeMin < first) {
         rangeMin = first;

--- a/unicorn/app/browser/components/Chart.jsx
+++ b/unicorn/app/browser/components/Chart.jsx
@@ -137,6 +137,7 @@ export default class Chart extends React.Component {
     }
 
     // init, render, and draw chart!
+    options.labelsUTC = true;
     options.dateWindow = this._chartRange;  // update viewport of range selector
     options.axes.y.valueRange = [metaData.min, metaData.max];  // lock y-axis
     this._previousDataSize = data.length;

--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -122,7 +122,7 @@ export default class ModelData extends React.Component {
             axisLabelWidth: 0,
             drawAxis: false,
             drawGrid: false,
-            valueFormatter: (time) => moment(time).utc().format('llll')
+            valueFormatter: (time) => moment.utc(time).format('llll')
           },
           y: {
             axisLabelOverflow: false,

--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -122,7 +122,7 @@ export default class ModelData extends React.Component {
             axisLabelWidth: 0,
             drawAxis: false,
             drawGrid: false,
-            valueFormatter: (time) => moment(time).format('llll')
+            valueFormatter: (time) => moment(time).utc().format('llll')
           },
           y: {
             axisLabelOverflow: false,

--- a/unicorn/app/browser/lib/Dygraphs/AxesCustomLabelsUnderlay.js
+++ b/unicorn/app/browser/lib/Dygraphs/AxesCustomLabelsUnderlay.js
@@ -102,7 +102,7 @@ export default function (context, canvas, area, dygraph) {
   canvas.strokeStyle = new RGBColor(muiTheme.palette.disabledColor).toRGB();
   for (let x=1; x<(xValues.length - 1); x++) {
     let xWidth = area.w - (x * xFactor);
-    let when = moment(xValues[x]).utc();
+    let when = moment.utc(xValues[x]);
     let date = when.format('ll');
     let time = when.format('LT');
 

--- a/unicorn/app/browser/lib/Dygraphs/AxesCustomLabelsUnderlay.js
+++ b/unicorn/app/browser/lib/Dygraphs/AxesCustomLabelsUnderlay.js
@@ -102,7 +102,7 @@ export default function (context, canvas, area, dygraph) {
   canvas.strokeStyle = new RGBColor(muiTheme.palette.disabledColor).toRGB();
   for (let x=1; x<(xValues.length - 1); x++) {
     let xWidth = area.w - (x * xFactor);
-    let when = moment(xValues[x]);
+    let when = moment(xValues[x]).utc();
     let date = when.format('ll');
     let time = when.format('LT');
 

--- a/unicorn/app/browser/stores/MetricDataStore.js
+++ b/unicorn/app/browser/stores/MetricDataStore.js
@@ -16,7 +16,6 @@
 // http://numenta.org/licenses/
 
 import BaseStore from 'fluxible/addons/BaseStore';
-import moment from 'moment';
 import {DATA_FIELD_INDEX} from '../lib/Constants';
 
 
@@ -60,7 +59,7 @@ export default class MetricDataStore extends BaseStore {
     let metric, newData;
     if (payload && 'metricId' in payload) {
       // Convert timestamp to Date
-      newData = payload.data.map((row) => [moment(row[0]).toDate(), row[1]]);
+      newData = payload.data.map((row) => [new Date(row[0]), row[1]]);
       metric = this._metrics.get(payload._metrics);
       if (metric) {
         // Append payload data to existing metric

--- a/unicorn/app/browser/stores/ModelDataStore.js
+++ b/unicorn/app/browser/stores/ModelDataStore.js
@@ -54,7 +54,12 @@ export default class ModelDataStore extends BaseStore {
    */
   _appendModelData(modelId, data) {
     // Convert timestamp to Date
-    let newData = data.map((row) => [moment(row[0]).toDate(), row[1], row[2]]);
+    //
+    // Assume we're receiving a timestamp without timezone data, e.g. output of
+    // Python's datetime.isoformat(). If there's non-UTC timezone data,
+    // e.g. "+04:00", this will shift the timestamp, which we don't want.
+    let newData = data.map((row) => [moment.utc(row[0]).toDate(),
+                                     row[1], row[2]]);
     let model = this._models.get(modelId);
     if (model) {
       // Append payload data to existing model

--- a/unicorn/app/main/DatabaseService.js
+++ b/unicorn/app/main/DatabaseService.js
@@ -902,7 +902,8 @@ export class DatabaseService {
               if (field.type === 'number') {
                 let metricData = {
                   metric_uid: field.uid,
-                  timestamp: moment(data[timestampField.index], timestampField.format).valueOf(), // eslint-disable-line
+                  timestamp: moment.utc(data[timestampField.index],
+                                        timestampField.format).valueOf(), // eslint-disable-line
                   metric_value: parseFloat(data[field.index])
                 };
                 // Save data

--- a/unicorn/app/main/FileService.js
+++ b/unicorn/app/main/FileService.js
@@ -64,7 +64,7 @@ SCHEMAS.forEach((schema) => {
  */
 function guessTimestampFormat(timestamp) {
   return TIMESTAMP_FORMATS.find((format) => {
-    return moment(timestamp, format, true).isValid();
+    return moment.utc(timestamp, format, true).isValid();
   });
 }
 
@@ -564,7 +564,7 @@ export class FileService {
               message += ' instead of having a format matching ' +
                          `'${field.format}'. For example: '${current}'`;
             }
-            return moment(value, field.format).isValid();
+            return moment.utc(value, field.format).isValid();
           default:
             return true;
           }

--- a/unicorn/app/main/TimeAggregator.js
+++ b/unicorn/app/main/TimeAggregator.js
@@ -15,7 +15,6 @@
 //
 // http://numenta.org/licenses/
 
-var moment = require('moment');  // eslint-disable-line no-var
 var Transform = require('stream').Transform; // eslint-disable-line no-var
 var util = require('util'); // eslint-disable-line no-var
 
@@ -45,7 +44,7 @@ util.inherits(TimeAggregator, Transform);
 
 TimeAggregator.prototype._transform = function (data, encoding, done) {
   if (this._timefield in data) {
-    let timestamp = moment(data[this._timefield]).valueOf();
+    let timestamp = new Date(data[this._timefield]);
     if (this._timebucket === 0) {
       this._timebucket = timestamp + this._interval;
     } else if (timestamp >= this._timebucket) {

--- a/unicorn/app/main/TimeAggregator.js
+++ b/unicorn/app/main/TimeAggregator.js
@@ -15,6 +15,7 @@
 //
 // http://numenta.org/licenses/
 
+var moment = require('moment');  // eslint-disable-line no-var
 var Transform = require('stream').Transform; // eslint-disable-line no-var
 var util = require('util'); // eslint-disable-line no-var
 
@@ -44,7 +45,7 @@ util.inherits(TimeAggregator, Transform);
 
 TimeAggregator.prototype._transform = function (data, encoding, done) {
   if (this._timefield in data) {
-    let timestamp = new Date(data[this._timefield]);
+    let timestamp = moment.utc(data[this._timefield]).valueOf();
     if (this._timebucket === 0) {
       this._timebucket = timestamp + this._interval;
     } else if (timestamp >= this._timebucket) {

--- a/unicorn/app/main/generateId.js
+++ b/unicorn/app/main/generateId.js
@@ -16,7 +16,6 @@
 // http://numenta.org/licenses/
 
 import crypto from 'crypto';
-import moment from 'moment';
 
 
 /**
@@ -61,7 +60,7 @@ export function generateMetricId(filename, metric) {
  */
 export function generateMetricDataId(metricId, timestamp) {
   if (!(timestamp instanceof Date)) {
-    timestamp = moment(timestamp);
+    timestamp = new Date(timestamp);
   }
   return `${metricId}!${timestamp.valueOf()}`;
 }

--- a/unicorn/app/main/index.js
+++ b/unicorn/app/main/index.js
@@ -78,7 +78,7 @@ function receiveModelData(modelId, data) {
   let [timestamp, value, score] = data; // eslint-disable-line
   let metricData = {
     metric_uid: modelId,
-    timestamp: moment(timestamp).valueOf(),
+    timestamp: moment.utc(timestamp).valueOf(),
     metric_value: value,
     anomaly_score: score
   };

--- a/unicorn/tests/js/integration/services/DatabaseService_test.js
+++ b/unicorn/tests/js/integration/services/DatabaseService_test.js
@@ -93,12 +93,24 @@ const EXPECTED_TIMESTAMP =  Object.assign({}, INSTANCES.Metric, {
 const EXPECTED_METRICS = [EXPECTED_TIMESTAMP, EXPECTED_METRIC];
 
 const EXPECTED_METRIC_DATA = [
-  {metric_uid: EXPECTED_METRIC_ID, timestamp: 1440557191000, metric_value: 21},
-  {metric_uid: EXPECTED_METRIC_ID, timestamp: 1440557251000, metric_value: 17},
-  {metric_uid: EXPECTED_METRIC_ID, timestamp: 1440557311000, metric_value: 22},
-  {metric_uid: EXPECTED_METRIC_ID, timestamp: 1440557371000, metric_value: 21},
-  {metric_uid: EXPECTED_METRIC_ID, timestamp: 1440557431000, metric_value: 16},
-  {metric_uid: EXPECTED_METRIC_ID, timestamp: 1440557491000, metric_value: 19}
+  {metric_uid: EXPECTED_METRIC_ID,
+   timestamp: Date.parse('2015-08-26T19:46:31Z'),
+   metric_value: 21},
+  {metric_uid: EXPECTED_METRIC_ID,
+   timestamp: Date.parse('2015-08-26T19:47:31Z'),
+   metric_value: 17},
+  {metric_uid: EXPECTED_METRIC_ID,
+   timestamp: Date.parse('2015-08-26T19:48:31Z'),
+   metric_value: 22},
+  {metric_uid: EXPECTED_METRIC_ID,
+   timestamp: Date.parse('2015-08-26T19:49:31Z'),
+   metric_value: 21},
+  {metric_uid: EXPECTED_METRIC_ID,
+   timestamp: Date.parse('2015-08-26T19:50:31Z'),
+   metric_value: 16},
+  {metric_uid: EXPECTED_METRIC_ID,
+   timestamp: Date.parse('2015-08-26T19:51:31Z'),
+   metric_value: 19}
 ];
 
 const NO_HEADER_CSV_FILE = path.join(FIXTURES, 'no-header.csv');


### PR DESCRIPTION
When we add a file to the database, we currently parse the string as if it's in the current time zone. Then we save this parsed timestamp's Unix time. For nonexistent times like 2015-03-08 02:30:00 GMT-0800, we save the UTC Unix time for 2015-03-08 03:30:00 GMT-0800. So multiple data points are saved for this timestamp, because the actual 3:30am datum is also parsed as 3:30am.

The chart retrieves this Unix time from the database and formats it as the current time zone, then displays it. So the Unix time remains constant throughout this whole process, it just matters how we parse the initial string.