### PR TITLE
UNI-386: Make sidebar scrollable. Polish the scrolling experience.

### DIFF
--- a/unicorn/app/browser/assets/styles/index.css
+++ b/unicorn/app/browser/assets/styles/index.css
@@ -24,7 +24,10 @@
 
 html {
   box-sizing: border-box;
+  /* Avoid the scroll top/bottom bounce effect. Don't let the html tag scroll. */
+  width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 *, *:before, *:after {

--- a/unicorn/app/browser/components/LeftNav.jsx
+++ b/unicorn/app/browser/components/LeftNav.jsx
@@ -49,13 +49,28 @@ export default class LeftNav extends React.Component {
     super(props, context);
 
     let muiTheme = this.context.muiTheme;
-    this._style = {
-      backgroundColor: muiTheme.leftNav.color,
-      height: '100%',
-      left: 0,
-      position: 'fixed',
-      top: 0,
-      width: muiTheme.leftNav.width
+    this._logoHeight = muiTheme.appBar.height * 1.2;
+    this._styles = {
+      root: {
+        backgroundColor: muiTheme.leftNav.color,
+        position: 'fixed',
+        left: 0,
+        top: 0,
+        bottom: 0,
+        width: muiTheme.leftNav.width
+      },
+      // Use another 'fixed' element rather than an 'absolute' element to dodge
+      // a Chromium bug that shifts the scrollbar to make room for a box shadow.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=582358
+      childrenContainer: {
+        position: 'fixed',
+        overflowX: 'hidden',
+        overflowY: 'auto',
+        top: this._logoHeight,
+        bottom: 0,
+        left: 0,
+        width: muiTheme.leftNav.width
+      }
     };
   }
 
@@ -65,9 +80,11 @@ export default class LeftNav extends React.Component {
    */
   render() {
     return (
-      <Paper style={this._style} zDepth={this.props.zDepth}>
-        <Logo />
-        {this.props.children}
+      <Paper style={this._styles.root} zDepth={this.props.zDepth}>
+        <Logo height={this._logoHeight} />
+        <div style={this._styles.childrenContainer}>
+          {this.props.children}
+        </div>
       </Paper>
     );
   }

--- a/unicorn/app/browser/components/Logo.jsx
+++ b/unicorn/app/browser/components/Logo.jsx
@@ -42,7 +42,7 @@ export default class Logo extends React.Component {
         backgroundColor: muiTheme.rawTheme.palette.primary2Color,
         borderBottom: '5px solid #29aae2',
         color: muiTheme.appBar.textColor,
-        height: muiTheme.appBar.height * 1.2,
+        height: props.height,
         margin: 0,
         padding: muiTheme.rawTheme.spacing.desktopGutter,
         paddingTop: muiTheme.rawTheme.spacing.desktopGutter - 5,

--- a/unicorn/app/browser/components/Main.jsx
+++ b/unicorn/app/browser/components/Main.jsx
@@ -78,7 +78,13 @@ export default class Main extends React.Component {
         fontWeight: muiTheme.rawTheme.font.weight.medium
       },
       models: {
-        marginLeft: 256,
+        position: 'fixed',
+        overflowX: 'hidden',
+        overflowY: 'auto',
+        top: 0,
+        bottom: 0,
+        right: 0,
+        left: muiTheme.leftNav.width,
         padding: '1rem'
       }
     };


### PR DESCRIPTION
The experience of scrolling the sidebar is now identical to the experience of scrolling the charts.

The changes:

- You can now scroll the sidebar. It scrolls independently of the chart area.
- The scrollbar is positioned correctly. I had to work around a Chromium bug.
- The scrollbars are the same color. Previously the scrollbar in the charts area
  was white because the operating system chose that color based on the
  background color. The background color is a gradient, which causes the OS to
  be weird and choose white (even though it chooses black if you use either
  gradient endpoint as a solid-colored background). Now that the scrollbar lives in
  a child element, this no longer happens. This is all a little bit goofy.

Additionally, the app no longer bounces up and down when you scroll to the top and bottom (like a webpage). Now it feels more like a real desktop app, similar to Atom. The bounces also had the issue of showing weird rendering artifacts sometimes.