### PR TITLE
UNI-437 Fix bug that causes multiple CreateModelDialog windows to open

### DIFF
--- a/unicorn/app/browser/components/CreateModelDialog.jsx
+++ b/unicorn/app/browser/components/CreateModelDialog.jsx
@@ -25,7 +25,6 @@ import React from 'react';
 
 import ChartUpdateViewpoint from '../actions/ChartUpdateViewpoint';
 import CreateModelStore from '../stores/CreateModelStore';
-import HideCreateModelDialogAction from '../actions/HideCreateModelDialog';
 import StartModelAction from '../actions/StartModel';
 import {trims} from '../../common/common-utils';
 
@@ -38,7 +37,6 @@ import {trims} from '../../common/common-utils';
   inputOpts: context.getStore(CreateModelStore).inputOpts,
   metricId: context.getStore(CreateModelStore).metricId,
   metricName: context.getStore(CreateModelStore).metricName,
-  open: context.getStore(CreateModelStore).open,
   paramFinderResults: context.getStore(CreateModelStore).paramFinderResults
 }))
 export default class CreateModelDialog extends React.Component {
@@ -84,7 +82,8 @@ export default class CreateModelDialog extends React.Component {
       viewpoint: null
     });
 
-    this.context.executeAction(HideCreateModelDialogAction);
+    this.props.dismiss();
+
     this.context.executeAction(StartModelAction, payload);
   }
 
@@ -95,7 +94,7 @@ export default class CreateModelDialog extends React.Component {
 
   render() {
     let {
-      fileName, inputOpts, metricId, metricName, paramFinderResults
+      fileName, inputOpts, metricId, metricName, paramFinderResults, open
     } = this.props;
     let body = null;
     let actions = [];
@@ -138,8 +137,21 @@ export default class CreateModelDialog extends React.Component {
             />
         );
       } else {
-        // No aggregation required, just start the model
-        this._startModel(rawPayload);
+        body = (
+          <div>
+            We determined that no aggregation is needed. The analysis will
+            continue using your raw data.
+          </div>
+        );
+
+        actions.push(
+          <RaisedButton
+            label={this._config.get('button:okay')}
+            onTouchTap={this._startModel.bind(this, rawPayload)}
+            primary={true}
+            style={this._styles.agg}
+          />
+        );
       }
     } else {
       body = (
@@ -155,7 +167,7 @@ export default class CreateModelDialog extends React.Component {
     }
 
     return (
-      <Dialog actions={actions} open={this.props.open} title={title}>
+      <Dialog actions={actions} open={open} title={title}>
         {body}
       </Dialog>
     );

--- a/unicorn/app/browser/components/Model.jsx
+++ b/unicorn/app/browser/components/Model.jsx
@@ -43,6 +43,7 @@ import ModelProgress from './ModelProgress';
 import ModelStore from '../stores/ModelStore';
 import ModelDataStore from '../stores/ModelDataStore';
 import ShowCreateModelDialogAction from '../actions/ShowCreateModelDialog';
+import HideCreateModelDialogAction from '../actions/HideCreateModelDialog';
 import StartParamFinderAction from '../actions/StartParamFinder';
 import {TIMESTAMP_FORMAT_PY_MAPPING} from '../../common/timestamp';
 import {
@@ -90,6 +91,7 @@ export default class Model extends React.Component {
     // init state
     this.state = {
       modalDialog: null,
+      showCreateModelDialog: false,
       showSnackbar: false,
       snackbarMessage: '',
       showNonAgg: false  // show raw data overlay on top of aggregate chart?
@@ -197,6 +199,19 @@ export default class Model extends React.Component {
     });
   }
 
+  _openCreateModelDialog(file, valueField) {
+    this.context.executeAction(ShowCreateModelDialogAction, {
+      fileName: file.name,
+      metricName: valueField.name
+    });
+    this.setState({showCreateModelDialog: true});
+  }
+
+  _dismissCreateModelDialog() {
+    this.setState({showCreateModelDialog: false});
+    this.context.executeAction(HideCreateModelDialogAction);
+  }
+
   _createModel(model, file, valueField, timestampField) {
     let inputOpts = {
       csv: file.filename,
@@ -205,10 +220,8 @@ export default class Model extends React.Component {
       valueIndex: valueField.index,
       datetimeFormat: TIMESTAMP_FORMAT_PY_MAPPING[timestampField.format]
     };
-    this.context.executeAction(ShowCreateModelDialogAction, {
-      fileName: file.name,
-      metricName: valueField.name
-    });
+
+    this._openCreateModelDialog(file, valueField);
 
     this.context.executeAction(StartParamFinderAction, {
       metricId: model.modelId,
@@ -473,7 +486,10 @@ export default class Model extends React.Component {
           title={modalDialog.title}>
             {modalDialog.body}
         </Dialog>
-        <CreateModelDialog ref="createModelWindow"/>
+        <CreateModelDialog
+          open={this.state.showCreateModelDialog}
+          dismiss={::this._dismissCreateModelDialog.bind(this)}
+          ref="createModelWindow"/>
         <Snackbar
           open={this.state.showSnackbar}
           message={this.state.snackbarMessage}

--- a/unicorn/app/browser/stores/CreateModelStore.js
+++ b/unicorn/app/browser/stores/CreateModelStore.js
@@ -43,7 +43,6 @@ export default class CreateModelStore extends BaseStore {
     this.fileName = null;
     this.metricId = null;
     this.metricName = null;
-    this.open = false;
     // Param Finder
     this.paramFinderResults = null;
     this.inputOpts = null;
@@ -59,7 +58,6 @@ export default class CreateModelStore extends BaseStore {
   _handleShowCreateModelDialog(payload) {
     this.fileName = payload.fileName;
     this.metricName = payload.metricName;
-    this.open = true;
     this.emitChange();
   }
 


### PR DESCRIPTION
Local open/close state was implemented in `CreateModelStore`, causing all dialogs to respond to show/hide actions. I moved the open/close state definition for `CreateModelDialog` to the parent component `Model`.

Additionally, this surface another issue where `_startModel` was being called in the render function. This caused an infinite loop when a state change was added to `_startModel`. Generally, components should not fire actions in the rendering process. I was forced to fix this by adding the `_startModel` action to a button. This is matches @marionleborgne's intended behavior for the dialog and will be extended further in UNI-428 (#754).

Merging this is a pre-requisite to merging #754 

One test failure `1) should export ModelData from the database` matches the test failure already on master.
 