### PR TITLE
UNI-424 Don't connect dots that are too far apart

### DIFF
--- a/unicorn/app/browser/components/Chart.jsx
+++ b/unicorn/app/browser/components/Chart.jsx
@@ -138,7 +138,7 @@ export default class Chart extends React.Component {
     // init, render, and draw chart!
     options.labelsUTC = true;
     options.dateWindow = this._chartRange;  // update viewport of range selector
-    options.axes.y.valueRange = [metaData.min, metaData.max];  // lock y-axis
+    options.axes.y.valueRange = [metaData.min, metaData.max];
     this._previousDataSize = data.length;
     this._dygraph = new Dygraph(element, data, options);
 
@@ -149,7 +149,7 @@ export default class Chart extends React.Component {
   }
 
   /**
-   * DyGrpahs Chart Update Logic and Re-Render
+   * DyGraphs Chart Update Logic and Re-Render
    */
   _chartUpdate() {
     let {data, metaData, options} = this.props;
@@ -180,6 +180,7 @@ export default class Chart extends React.Component {
     }
 
     // update chart
+    options.axes.y.valueRange = [metaData.min, metaData.max];
     options.dateWindow = this._chartRange;
     options.file = data;  // new data
     this._previousDataSize = data.length;

--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -129,8 +129,8 @@ function insertIntoGaps(data, vals) {
  */
 function prepareData(
   metricRecords, modelRecords, aggregated, rawDataInBackground) {
-  let minVal = Math.POSITIVE_INFINITY;
-  let maxVal = Math.NEGATIVE_INFINITY;
+  let minVal = Number.POSITIVE_INFINITY;
+  let maxVal = Number.NEGATIVE_INFINITY;
 
   let aggregatedChartData = null;
   if (modelRecords.length && aggregated) {


### PR DESCRIPTION
Disable interpolation when we detect a time gap in the data.

Add a simple initial heuristic for detecting gaps. Compute all the time-deltas, find the 75th percentile, and multiply it by a factor (currently 1.5). The result is the gap threshold. This heuristic will be easy to tweak now that it's in place.

We have to detect gaps in aggregated and unaggregated data independently, and then merge them. This was difficult to fit into the existing code, so I shuffled the way we compute the Dygraphs input data.