### PR TITLE
UNI-438 Bugfix: skipping many raw data points when merging with aggregated

### DIFF
--- a/unicorn/app/browser/components/Chart.jsx
+++ b/unicorn/app/browser/components/Chart.jsx
@@ -138,7 +138,7 @@ export default class Chart extends React.Component {
     // init, render, and draw chart!
     options.labelsUTC = true;
     options.dateWindow = this._chartRange;  // update viewport of range selector
-    options.axes.y.valueRange = [metaData.min, metaData.max];  // lock y-axis
+    options.axes.y.valueRange = [metaData.min, metaData.max];
     this._previousDataSize = data.length;
     this._dygraph = new Dygraph(element, data, options);
 
@@ -149,7 +149,7 @@ export default class Chart extends React.Component {
   }
 
   /**
-   * DyGrpahs Chart Update Logic and Re-Render
+   * DyGraphs Chart Update Logic and Re-Render
    */
   _chartUpdate() {
     let {data, metaData, options} = this.props;
@@ -180,6 +180,7 @@ export default class Chart extends React.Component {
     }
 
     // update chart
+    options.axes.y.valueRange = [metaData.min, metaData.max];
     options.dateWindow = this._chartRange;
     options.file = data;  // new data
     this._previousDataSize = data.length;

--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -77,32 +77,8 @@ function sortedMerge(a, b, compareFunction) {
  * @returns {Array} - data with gap values inserted
  */
 function insertIntoGaps(data, vals) {
-  let deltas = [];
-  for (let i = 1; i < data.length; i++) {
-    deltas.push(data[i][DATA_INDEX_TIME].getTime() -
-                data[i-1][DATA_INDEX_TIME].getTime());
-  }
-  deltas.sort();
-
-  let percentile = 0.75;
-  let gapThreshold = 1.5 * deltas[Math.floor(deltas.length*percentile)];
-
-  let newData = [];
-  data.forEach((item, rowid) => {
-    newData.push(item);
-
-    if (rowid + 1 < data.length) {
-      let curr = item[DATA_INDEX_TIME].getTime();
-      let next = data[rowid+1][DATA_INDEX_TIME].getTime();
-      let delta = next - curr;
-      if (delta > gapThreshold) {
-        let gapItem = [new Date(curr + delta/2)].concat(vals);
-        newData.push(gapItem);
-      }
-    }
-  });
-
-  return newData;
+  // Heuristic: do nothing.
+  return data;
 }
 
 /**
@@ -247,13 +223,6 @@ export default class ModelData extends React.Component {
       options: {
         axisLineColor: muiTheme.rawTheme.palette.accent4Color,
         connectSeparatedPoints: true,  // required for raw+agg overlay
-
-        // We want these, but it causes problems.
-        // https://github.com/danvk/dygraphs/issues/745
-        //
-        // drawGapEdgePoints: true,
-        // pointSize: 3,
-
         includeZero: true,
         interactionModel: Dygraph.Interaction.dragIsPanInteractionModel,
         labelsShowZeroValues: true,

--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -129,8 +129,8 @@ function insertIntoGaps(data, vals) {
  */
 function prepareData(
   metricRecords, modelRecords, aggregated, rawDataInBackground) {
-  let minVal = Math.POSITIVE_INFINITY;
-  let maxVal = Math.NEGATIVE_INFINITY;
+  let minVal = Number.POSITIVE_INFINITY;
+  let maxVal = Number.NEGATIVE_INFINITY;
 
   let aggregatedChartData = null;
   if (modelRecords.length && aggregated) {


### PR DESCRIPTION
The issue here was in `_overlayDataSeries`. It's using a `.forEach` and not always doing something with the `item`.

I already reworked the way we build up this data for another change: https://github.com/numenta/numenta-apps/pull/761 . It fixes the bug. We're still discussing that change, so this PR is just that one without the controversial parts.