### PR TITLE
UNI-423 Use a single y scale for aggregated and raw data

### DIFF
--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -274,18 +274,9 @@ export default class ModelData extends React.Component {
       // non-aggregated line chart overlay on top of aggregated data line chart
       raw: {
         labels: ['NonAggregated'],
-        axes: {
-          y2: {
-            axisLabelOverflow: false,
-            axisLabelWidth: 0,
-            drawAxis: false,
-            drawGrid: false,
-            valueFormatter: ::this._legendValueFormatter
-          }
-        },
         series: {
           NonAggregated: {
-            axis: 'y2',
+            axis: 'y',
             color: muiTheme.rawTheme.palette.primary1Color,  // light blue
             independentTicks: false,
             showInRangeSelector: false,


### PR DESCRIPTION
We don't currently set the valueRange of the "show non-aggregated" data, so its y scale (which doesn't have a visualized axis) quietly changes based on the selected timestep range.

Instead of giving it its own valueRange, just unite with the aggregated data. Share a y scale. Arguably we'd want to draw a second y axis if we want two different y scales.