### PR TITLE
ENG-105 Fix DATETIME and TIMESTAMP mysql column defaults to work with MySQL 5.7.8+

### DIFF
--- a/htm-it-mobile/pipeline/requirements.txt
+++ b/htm-it-mobile/pipeline/requirements.txt
@@ -1,4 +1,4 @@
 boto==2.27.0
-fabric==1.9.0
+fabric==1.11.1
 jenkinsapi==0.2.25
 PyYAML==3.10

--- a/htm.it/htm/it/app/repository/migrations/versions/000_3a7e06671df4_base_to_1.6.py
+++ b/htm.it/htm/it/app/repository/migrations/versions/000_3a7e06671df4_base_to_1.6.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Copyright (C) 2015-2016, Numenta, Inc.  Unless you have purchased from
 # Numenta, Inc. a separate commercial license for this software code, the
 # following terms and conditions apply:
 #
@@ -68,7 +68,7 @@ def upgrade():
       sa.Column("server", sa.VARCHAR(length=100), server_default="",
                 nullable=False),
       sa.Column("timestamp", sa.TIMESTAMP(),
-                server_default="0000-00-00 00:00:00", nullable=False),
+                server_default=None, nullable=False),
       sa.Column("status", sa.VARCHAR(length=32), server_default="",
                 nullable=False),
       sa.PrimaryKeyConstraint("server", "timestamp")
@@ -86,7 +86,9 @@ def upgrade():
       "annotation",
       sa.Column("uid", sa.VARCHAR(length=40), nullable=False),
       sa.Column("timestamp", sa.TIMESTAMP(), nullable=False),
-      sa.Column("created", sa.TIMESTAMP(), nullable=False),
+      sa.Column("created", sa.TIMESTAMP(),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False),
       sa.Column("device", sa.VARCHAR(length=40), nullable=True),
       sa.Column("user", sa.VARCHAR(length=100), nullable=True),
       sa.Column("server", sa.VARCHAR(length=100), nullable=True),

--- a/htm.it/htm/it/app/repository/migrations/versions/001_2f1ee984f978_1.6_to_1.7.py
+++ b/htm.it/htm/it/app/repository/migrations/versions/001_2f1ee984f978_1.6_to_1.7.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Copyright (C) 2015-2016, Numenta, Inc.  Unless you have purchased from
 # Numenta, Inc. a separate commercial license for this software code, the
 # following terms and conditions apply:
 #
@@ -60,13 +60,13 @@ def upgrade():
 
   op.alter_column("annotation", "created",
                   type_=sa.DATETIME,
-                  existing_nullable=False,
-                  existing_server_default=sa.text("'0000-00-00 00:00:00'"))
+                  server_default=None,
+                  existing_nullable=False)
 
   op.alter_column("instance_status_history", "timestamp",
                   type_=sa.DATETIME,
-                  existing_nullable=False,
-                  existing_server_default=sa.text("'0000-00-00 00:00:00'"))
+                  server_default=None,
+                  existing_nullable=False)
 
   op.alter_column("metric", "last_timestamp",
                   type_=sa.DATETIME,

--- a/htm.it/htm/it/app/repository/migrations/versions/002_3b26d099594d_fix_datetime_and_timestamp_defaults.py
+++ b/htm.it/htm/it/app/repository/migrations/versions/002_3b26d099594d_fix_datetime_and_timestamp_defaults.py
@@ -19,11 +19,11 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-"""timestatmp to datetime
+"""fix DATETIME and TIMESTAMP defaults
 
-Revision ID: 1d2eddc43366
-Revises: 57ab75d58038
-Create Date: 2014-12-30 15:58:52.062058
+Revision ID: 3b26d099594d
+Revises: 2f1ee984f978
+Create Date: 2016-05-11 17:04:36.725605
 """
 
 from alembic import op
@@ -31,30 +31,27 @@ import sqlalchemy as sa
 
 
 # Revision identifiers, used by Alembic. Do not change.
-revision = '1d2eddc43366'
-down_revision = '57ab75d58038'
+revision = '3b26d099594d'
+down_revision = '2f1ee984f978'
 
 
 
 def upgrade():
-  """ Change tables to use DATETIME column types instead of TIMESTAMP """
-  # Change tables to use DATETIME column types instead of TIMESTAMP
-  op.alter_column("instance_status_history", "timestamp",
-                  type_=sa.DATETIME,
-                  server_default=None,
-                  existing_nullable=False)
+    """Fix server defaults for DATETIME columns, because
+    0 ("0000-00-00 00:00:00") is deprecated as default for those colum types
+    as of mysql 5.7.8, and will fail with mysql installed with default config.
+    """
+    op.alter_column("annotation", "created",
+                    server_default=None,
+                    existing_type=sa.DATETIME,
+                    existing_nullable=False)
 
-  op.alter_column("metric", "last_timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=True,
-                  existing_server_default=sa.text("NULL"))
-
-  op.alter_column("metric_data", "timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=False)
-  ### end Alembic commands ###
+    op.alter_column("instance_status_history", "timestamp",
+                    server_default=None,
+                    existing_type=sa.DATETIME,
+                    existing_nullable=False)
 
 
 
 def downgrade():
-  raise NotImplementedError("Rollback is not supported.")
+    raise NotImplementedError("Rollback is not supported.")

--- a/htm.it/htm/it/pipeline/requirements.txt
+++ b/htm.it/htm/it/pipeline/requirements.txt
@@ -1,2 +1,2 @@
-fabric==1.9.0
+fabric==1.11.1
 PyYAML==3.10

--- a/htm.it/requirements.txt
+++ b/htm.it/requirements.txt
@@ -10,14 +10,14 @@ validictory==0.9.1
 
 # Required by htm-it
 boto==2.38.0
-fabric==1.9.0
+fabric==1.11.1
 msgpack-python==0.3.0
 paste==1.7.5.1
 pytz==2015.7
 requests==2.0.1
 sphinx==1.1.3
 supervisor==3.1.3
-uwsgi==2.0.4
+uwsgi==2.0.12
 web.py==0.37
 sqlalchemy==0.9.4
 alembic==0.6.7

--- a/htm.it/setup.py
+++ b/htm.it/setup.py
@@ -29,7 +29,8 @@ except ImportError:
     from os.path import exists
     if exists("paver-minilib.zip"):
         import sys
-        sys.path.insert(0, "paver-minilib.zip")
+        sys.path.insert(0, os.path.join(os.path.split(__file__)[0],
+                                        "paver-minilib.zip"))
     import paver.tasks
 
 import psutil

--- a/htm.it/tests/py/integration/app/runtime/aggregator_metric_collection_test.py
+++ b/htm.it/tests/py/integration/app/runtime/aggregator_metric_collection_test.py
@@ -188,7 +188,7 @@ class AggregatorMetricCollectionTestCase(unittest.TestCase):
 
     with self.engine.connect() as conn:
       autostack1 = self._addAutostack(name="testCollectMetricData1",
-                                      region="us-east-1",
+                                      region="us-west-2",
                                       filters='{"tag:Name": ["*"]}')
 
       m1a = self._addAutostackMetric(conn, autostack1)
@@ -388,13 +388,13 @@ class AggregatorMetricCollectionTestCase(unittest.TestCase):
 
       return autostackObj, metricObj
 
-    # All instances in us-east-1
+    # All instances in us-west-2
     engine = repository.engineFactory()
     with engine.begin() as conn:
       autostack1, m1 = (
         _createAutostackMetric(conn,
                                name="testCollectMetricStats1",
-                               region="us-east-1",
+                               region="us-west-2",
                                filters={"tag:Name": ["*"]}))
 
       stats1 = collector.collectMetricStatistics(

--- a/htmengine/README.md
+++ b/htmengine/README.md
@@ -178,7 +178,7 @@ Create a `conf/` directory, and use the following files as templates for your ow
 ```
 CREATE TABLE instance_status_history (
     server VARCHAR(100) DEFAULT '' NOT NULL,
-    timestamp DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+    timestamp DATETIME NOT NULL,
     status VARCHAR(32) DEFAULT '' NOT NULL,
     PRIMARY KEY (server, timestamp)
 );

--- a/htmengine/htmengine/repository/schema.py
+++ b/htmengine/htmengine/repository/schema.py
@@ -50,7 +50,7 @@ instance_status_history = Table(  # pylint: disable=C0103
                                        DATETIME(),
                                        primary_key=True,
                                        nullable=False,
-                                       server_default="0000-00-00 00:00:00"),
+                                       server_default=None),
                                 Column("status",
                                        VARCHAR(length=32),
                                        nullable=False,

--- a/htmengine/tests/support/skeleton-app/migrations/versions/000_57ab75d58038_initial_htmengine.py
+++ b/htmengine/tests/support/skeleton-app/migrations/versions/000_57ab75d58038_initial_htmengine.py
@@ -43,7 +43,7 @@ def upgrade():
   op.create_table('instance_status_history',
     sa.Column('server', sa.VARCHAR(length=100), server_default='',
               nullable=False),
-    sa.Column('timestamp', sa.TIMESTAMP(), server_default='0000-00-00 00:00:00',
+    sa.Column('timestamp', sa.TIMESTAMP(), server_default=None,
               nullable=False),
     sa.Column('status', sa.VARCHAR(length=32), server_default='',
               nullable=False),

--- a/htmengine/tests/support/skeleton-app/migrations/versions/002_872a895b8e8_fix_datetime_and_timestamp_defaults.py
+++ b/htmengine/tests/support/skeleton-app/migrations/versions/002_872a895b8e8_fix_datetime_and_timestamp_defaults.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Copyright (C) 2015-2016, Numenta, Inc.  Unless you have purchased from
 # Numenta, Inc. a separate commercial license for this software code, the
 # following terms and conditions apply:
 #
@@ -19,11 +19,11 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-"""timestatmp to datetime
+"""fix DATETIME and TIMESTAMP defaults
 
-Revision ID: 1d2eddc43366
-Revises: 57ab75d58038
-Create Date: 2014-12-30 15:58:52.062058
+Revision ID: 872a895b8e8
+Revises: 1d2eddc43366
+Create Date: 2016-05-11 18:42:24.861060
 """
 
 from alembic import op
@@ -31,30 +31,22 @@ import sqlalchemy as sa
 
 
 # Revision identifiers, used by Alembic. Do not change.
-revision = '1d2eddc43366'
-down_revision = '57ab75d58038'
+revision = '872a895b8e8'
+down_revision = '1d2eddc43366'
 
 
 
 def upgrade():
-  """ Change tables to use DATETIME column types instead of TIMESTAMP """
-  # Change tables to use DATETIME column types instead of TIMESTAMP
-  op.alter_column("instance_status_history", "timestamp",
-                  type_=sa.DATETIME,
-                  server_default=None,
-                  existing_nullable=False)
-
-  op.alter_column("metric", "last_timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=True,
-                  existing_server_default=sa.text("NULL"))
-
-  op.alter_column("metric_data", "timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=False)
-  ### end Alembic commands ###
+    """Fix server defaults for DATETIME columns, because
+    0 ("0000-00-00 00:00:00") is deprecated as default for those colum types
+    as of mysql 5.7.8, and will fail with mysql installed with default config.
+    """
+    op.alter_column("instance_status_history", "timestamp",
+                    server_default=None,
+                    existing_type=sa.DATETIME,
+                    existing_nullable=False)
 
 
 
 def downgrade():
-  raise NotImplementedError("Rollback is not supported.")
+    raise NotImplementedError("Rollback is not supported.")

--- a/infrastructure/ami-tools/packer-scripts/configure-htm-it-pipeline-centos7-ami
+++ b/infrastructure/ami-tools/packer-scripts/configure-htm-it-pipeline-centos7-ami
@@ -113,7 +113,7 @@ install-htm-it() {
 
   # Install HTM-IT pre-requisites
   pip install paver==1.2.4 agamotto==0.5.1 --target "${NUMENTA}/lib/python2.7/site-packages"
-  pip install uwsgi==2.0.4 --install-option="--prefix=${NUMENTA}"
+  pip install uwsgi==2.0.12 --install-option="--prefix=${NUMENTA}"
 
   # Clone Numenta Apps Repo
   cd "${NUMENTA}"

--- a/infrastructure/requirements.txt
+++ b/infrastructure/requirements.txt
@@ -1,5 +1,5 @@
 boto==2.38.0
-fabric==1.9.0
+fabric==1.11.1
 grokcli
 jenkinsapi==0.2.28
 PyYAML==3.11

--- a/install-htm-it-from-bare-centos7.sh
+++ b/install-htm-it-from-bare-centos7.sh
@@ -68,7 +68,7 @@ git clone https://github.com/numenta/numenta-apps.git /opt/numenta/numenta-apps
 # Install HTM-IT
 cd /opt/numenta/numenta-apps/
 pip install paver==1.2.4 --user
-pip install uwsgi==2.0.4 --user
+pip install uwsgi==2.0.12 --user
 pip install agamotto==0.5.1 --user
 ./install-htm-it.sh /home/centos/.local
 

--- a/taurus-mobile/pipeline/requirements.txt
+++ b/taurus-mobile/pipeline/requirements.txt
@@ -1,4 +1,4 @@
 boto==2.27.0
-fabric==1.9.0
+fabric==1.11.1
 jenkinsapi==0.2.25
 PyYAML==3.10

--- a/taurus/taurus/engine/repository/migrations/versions/000_57ab75d58038_initial_htmengine.py
+++ b/taurus/taurus/engine/repository/migrations/versions/000_57ab75d58038_initial_htmengine.py
@@ -43,7 +43,7 @@ def upgrade():
   op.create_table('instance_status_history',
     sa.Column('server', sa.VARCHAR(length=100), server_default='',
               nullable=False),
-    sa.Column('timestamp', sa.TIMESTAMP(), server_default='0000-00-00 00:00:00',
+    sa.Column('timestamp', sa.TIMESTAMP(), server_default=None,
               nullable=False),
     sa.Column('status', sa.VARCHAR(length=32), server_default='',
               nullable=False),

--- a/taurus/taurus/engine/repository/migrations/versions/001_1d2eddc43366_timestatmp_to_datetime.py
+++ b/taurus/taurus/engine/repository/migrations/versions/001_1d2eddc43366_timestatmp_to_datetime.py
@@ -41,8 +41,8 @@ def upgrade():
   # Change tables to use DATETIME column types instead of TIMESTAMP
   op.alter_column("instance_status_history", "timestamp",
                   type_=sa.DATETIME,
-                  existing_nullable=False,
-                  existing_server_default=sa.text("'0000-00-00 00:00:00'"))
+                  server_default=None,
+                  existing_nullable=False)
 
   op.alter_column("metric", "last_timestamp",
                   type_=sa.DATETIME,

--- a/taurus/taurus/engine/repository/migrations/versions/002_a60d03066072_fix_datetime_and_timestamp_defaults.py
+++ b/taurus/taurus/engine/repository/migrations/versions/002_a60d03066072_fix_datetime_and_timestamp_defaults.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Copyright (C) 2016, Numenta, Inc.  Unless you have purchased from
 # Numenta, Inc. a separate commercial license for this software code, the
 # following terms and conditions apply:
 #
@@ -19,11 +19,11 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-"""timestatmp to datetime
+"""fix DATETIME and TIMESTAMP defaults
 
-Revision ID: 1d2eddc43366
-Revises: 57ab75d58038
-Create Date: 2014-12-30 15:58:52.062058
+Revision ID: a60d03066072
+Revises: 1d2eddc43366
+Create Date: 2016-05-11 15:14:35.893462
 """
 
 from alembic import op
@@ -31,30 +31,22 @@ import sqlalchemy as sa
 
 
 # Revision identifiers, used by Alembic. Do not change.
-revision = '1d2eddc43366'
-down_revision = '57ab75d58038'
+revision = 'a60d03066072'
+down_revision = '1d2eddc43366'
 
 
 
 def upgrade():
-  """ Change tables to use DATETIME column types instead of TIMESTAMP """
-  # Change tables to use DATETIME column types instead of TIMESTAMP
-  op.alter_column("instance_status_history", "timestamp",
-                  type_=sa.DATETIME,
-                  server_default=None,
-                  existing_nullable=False)
-
-  op.alter_column("metric", "last_timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=True,
-                  existing_server_default=sa.text("NULL"))
-
-  op.alter_column("metric_data", "timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=False)
-  ### end Alembic commands ###
+    """Fix server defaults for DATETIME columns, because
+    0 ("0000-00-00 00:00:00") is deprecated as default for those colum types
+    as of mysql 5.7.8, and will fail with mysql installed with default config.
+    """
+    op.alter_column("instance_status_history", "timestamp",
+                    server_default=None,
+                    existing_type=sa.DATETIME,
+                    existing_nullable=False)
 
 
 
 def downgrade():
-  raise NotImplementedError("Rollback is not supported.")
+    raise NotImplementedError("Rollback is not supported.")


### PR DESCRIPTION
Fixes #779 

Fix server defaults for DATETIME and TIMESTAMP columns in taurus.engine, because
0 ("0000-00-00 00:00:00") is deprecated as default for those colum types
as of mysql 5.7.8, and will fail with mysql installed with default config

Fix server defaults for DATETIME and TIMESTAMP columns in htm.it, because
0 ("0000-00-00 00:00:00") is deprecated as default for those colum types
as of mysql 5.7.8, and will fail with mysql installed with default config.

Point tests in app/runtime/aggregator_metric_collection_test.py that require running instances to
the us-west-2 region, since we have no more running test EC2 instances in us-east-1

Fix default in instance_status_history.timestamp column of the htmengine's sleleton-app database.