### PR TITLE
Zooming: don't assume equally spaced data

### DIFF
--- a/unicorn/app/browser/components/Chart.jsx
+++ b/unicorn/app/browser/components/Chart.jsx
@@ -157,7 +157,8 @@ export default class Chart extends React.Component {
     options.dateWindow = this._chartRange;  // update viewport of range selector
     this._previousDataSize = data.length;
     this._dygraph = new CustomDygraph(element, data, options,
-      this.props.yScaleCalculate);
+                                      this.props.xScaleCalculate,
+                                      this.props.yScaleCalculate);
 
     // after: track chart viewport position changes
     rangeEl = element.getElementsByClassName(RANGE_SELECTOR_CLASS)[0];

--- a/unicorn/app/browser/components/Chart.jsx
+++ b/unicorn/app/browser/components/Chart.jsx
@@ -24,11 +24,21 @@ import ChartUpdateViewpoint from '../actions/ChartUpdateViewpoint';
 import Dygraph from 'dygraphs';
 import '../lib/Dygraphs/Plugins';
 import CustomDygraph from '../lib/Dygraphs/CustomDygraph';
-import {DATA_FIELD_INDEX} from '../lib/Constants';
+import {ANOMALY_BAR_WIDTH, DATA_FIELD_INDEX} from '../lib/Constants';
 
 const {DATA_INDEX_TIME} = DATA_FIELD_INDEX;
 const RANGE_SELECTOR_CLASS = 'dygraph-rangesel-fgcanvas';
 
+function getDateWindowWidth(resolution, chartElement) {
+  switch (resolution.per) {
+  case 'anomaly bar':
+    return resolution.timespan * (chartElement.offsetWidth / ANOMALY_BAR_WIDTH);
+  case 'chart width':
+    return resolution.timespan;
+  default:
+    throw new Error(`Unrecognized resolution 'per': ${resolution.per}`);
+  }
+}
 
 /**
  * Chart Widget. Wraps as a React Component.
@@ -86,7 +96,7 @@ export default class Chart extends React.Component {
   }
 
   componentDidMount() {
-    this._chartInitalize();
+    this._chartInitialize();
   }
 
   componentWillUnmount() {
@@ -95,9 +105,9 @@ export default class Chart extends React.Component {
 
   componentDidUpdate() {
     if (!this._dygraph) {
-      this._chartInitalize();
+      this._chartInitialize();
     } else {
-      this._chartUpdate(true);
+      this._chartUpdate();
     }
   }
 
@@ -121,24 +131,19 @@ export default class Chart extends React.Component {
   }
 
   /**
-   * DyGrpahs Chart Initalize and Render
+   * Dygraphs Chart Initialize and Render
    */
-  _chartInitalize() {
-    let {data, metaData, options} = this.props;
+  _chartInitialize() {
+    let {data, metaData, options, resolution} = this.props;
 
     if (data.length < 2) return;
 
-    let {metric, model, displayPointCount} = metaData;
-    let element = ReactDOM.findDOMNode(this.refs[`chart-${model.modelId}`]);
+    let {metric, model} = metaData;
     let first = data[0][DATA_INDEX_TIME].getTime();
     let last = data[data.length - 1][DATA_INDEX_TIME].getTime();
-    let rangeEl, unit;
-    if (model.ran) {
-      unit = (last - first) / model.dataSize;
-    } else {
-      unit = (last - first) / metric.dataSize;
-    }
-    let rangeWidth = unit * displayPointCount;
+
+    let element = ReactDOM.findDOMNode(this.refs[`chart-${model.modelId}`]);
+    let rangeWidth = getDateWindowWidth(resolution, element);
 
     let rangeMin = first;
     // move chart back to last valid display position from previous viewing
@@ -161,54 +166,58 @@ export default class Chart extends React.Component {
                                       this.props.yScaleCalculate);
 
     // after: track chart viewport position changes
-    rangeEl = element.getElementsByClassName(RANGE_SELECTOR_CLASS)[0];
+    let rangeEl = element.getElementsByClassName(RANGE_SELECTOR_CLASS)[0];
     Dygraph.addEvent(rangeEl, 'mousedown', this._handleMouseDown.bind(this));
     Dygraph.addEvent(element, 'mouseup', this._handleMouseUp.bind(this));
   }
 
   /**
-   * DyGraphs Chart Update Logic and Re-Render
-   * @param {boolean} resetZoom Whether or not to reset the zoom level
+   * Dygraphs Chart Update Logic and Re-Render
    */
-  _chartUpdate(resetZoom) {
-    let {data, metaData, options} = this.props;
+  _chartUpdate() {
+    let {data, metaData, options, resolution} = this.props;
 
     if (data.length < 1) return;
 
-    let {model,  metric, displayPointCount} = metaData;
-    let modelIndex = Math.abs(model.dataSize - 1);
-    let first = data[0][DATA_INDEX_TIME].getTime();
-    let last = data[data.length - 1][DATA_INDEX_TIME].getTime();
+    let {model, modelData} = metaData;
 
+    let element = ReactDOM.findDOMNode(this.refs[`chart-${model.modelId}`]);
+    let rangeWidth = getDateWindowWidth(resolution, element);
 
-    let [rangeMin, rangeMax] = this._chartRange;
-
-    let unit;
-    if (model.ran) {
-      unit = (last - first) / model.dataSize;
+    if (model.active && this._scrollLock && model.dataSize > 0) {
+      // Move to rightmost model result.
+      let first = data[0][DATA_INDEX_TIME].getTime();
+      let lastResult = modelData.data[model.dataSize - 1];
+      this._chartRange[1] = lastResult[DATA_INDEX_TIME].getTime();
+      this._chartRange[0] = Math.max(first, this._chartRange[1] - rangeWidth);
+      if (this._chartRange[1] - this._chartRange[0] < rangeWidth) {
+        this._chartRange[1] = this._chartRange[0] + rangeWidth;
+      }
     } else {
-      unit = (last - first) / metric.dataSize;
-    }
-
-    let rangeWidth = unit * displayPointCount;
-    if (resetZoom) {
-      rangeMax = rangeMin + rangeWidth;
-      if (rangeMax > last) {
-        rangeMax = last;
-        rangeMin = last - rangeWidth;
+      let discrepancy = rangeWidth - (this._chartRange[1] -
+                                      this._chartRange[0]);
+      if (discrepancy < 0) {
+        // Shrink the right side.
+        this._chartRange[1] = this._chartRange[1] + discrepancy;
+      } else if (discrepancy > 0) {
+        // Grow the right side.
+        this._chartRange[1] = Math.min(data[data.length-1][DATA_INDEX_TIME],
+                                       this._chartRange[1] + discrepancy);
+        discrepancy = rangeWidth - (this._chartRange[1] -
+                                    this._chartRange[0]);
+        if (discrepancy > 0) {
+          // Grow the left side.
+          this._chartRange[0] = Math.max(data[0][DATA_INDEX_TIME],
+                                         this._chartRange[0] - discrepancy);
+          discrepancy = rangeWidth - (this._chartRange[1] -
+                                      this._chartRange[0]);
+          if (discrepancy > 0) {
+            // Force-grow the right side.
+            this._chartRange[1] = this._chartRange[1] + discrepancy;
+          }
+        }
       }
     }
-
-    if (model.active && this._scrollLock) {
-      rangeMax = data[modelIndex][DATA_INDEX_TIME].getTime();
-      rangeMin = rangeMax - rangeWidth;
-      if (rangeMin < first) {
-        rangeMin = first;
-        rangeMax = rangeMin + rangeWidth;
-      }
-    }
-
-    this._chartRange = [rangeMin, rangeMax];
 
     // update chart
     options.dateWindow = this._chartRange;
@@ -253,7 +262,7 @@ export default class Chart extends React.Component {
 
     // update chart
     this._chartRange = [newMin, newMax];
-    this._chartUpdate(false);
+    this._chartUpdate();
   }
 
   /**

--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -256,15 +256,22 @@ function xScaleCalculate(context, g) {
     let minSpread = context._minTimeDelta * anomalyBarCount;
     let discrepancy = minSpread - (adjusted[1] - adjusted[0]);
     if (discrepancy > 0) {
+      // Grow both sides, trying to hold the midpoint constant.
+      adjusted[0] = Math.max(data[0][DATA_INDEX_TIME],
+                             adjusted[0] - discrepancy/2);
       adjusted[1] = Math.min(data[data.length-1][DATA_INDEX_TIME],
-                             adjusted[1] + discrepancy);
+                             adjusted[1] + discrepancy/2);
       discrepancy = minSpread - (adjusted[1] - adjusted[0]);
       if (discrepancy > 0) {
+        // One of the sides hit the end. Put the remainder on the other side.
         adjusted[0] = Math.max(data[0][DATA_INDEX_TIME],
                                adjusted[0] - discrepancy);
+        adjusted[1] = Math.min(data[data.length-1][DATA_INDEX_TIME],
+                               adjusted[1] + discrepancy);
         discrepancy = minSpread - (adjusted[1] - adjusted[0]);
         if (discrepancy > 0) {
-          // Now force extra space to the right.
+          // Both sides hit the end.
+          // Force extra space to the right.
           adjusted[1] += discrepancy;
         }
       }

--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -253,7 +253,7 @@ function xScaleCalculate(context, g) {
     adjusted[0] = Math.max(adjusted[0], data[0][DATA_INDEX_TIME]);
 
     // Must be zoomed out enough that the space is filled with anomaly bars.
-    let anomalyBarCount = g.getArea().w / ANOMALY_BAR_WIDTH;
+    let anomalyBarCount = g.canvas_.offsetWidth / ANOMALY_BAR_WIDTH;
     let minSpread = context._minTimeDelta * anomalyBarCount;
     let discrepancy = minSpread - (adjusted[1] - adjusted[0]);
     if (discrepancy > 0) {

--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -301,6 +301,13 @@ function yScaleCalculate(context, g) {
   return yExtentAdjusted;
 }
 
+function onChartResize(context) {
+  // Get chart actual width used to calculate the initial number of bars
+  let modelId = context.props.modelId;
+  let chart = ReactDOM.findDOMNode(context.refs[`chart-${modelId}`]);
+  context.setState({chartWidth: chart.offsetWidth});
+}
+
 /**
  * React Component for sending Model Data from Model component to
  *  Chart component.
@@ -383,6 +390,8 @@ export default class ModelData extends React.Component {
     this._yScaleCalculate = function (context, dygraph) {
       return yScaleCalculate(context, dygraph);
     }.bind(null, this);
+
+    this._onChartResize = onChartResize.bind(null, this);
 
     // Dygraphs Chart Options: Global and per-Series/Axis settings.
     this._chartOptions = {
@@ -608,11 +617,12 @@ export default class ModelData extends React.Component {
   }
 
   componentDidMount() {
-    // Get chart actual width used to calculate the initial number of bars
-    let modelId = this.props.modelId;
-    let chart = ReactDOM.findDOMNode(this.refs[`chart-${modelId}`]);
-    // TODO we also need this on chart resize
-    this.setState({chartWidth: chart.offsetWidth});
+    this._onChartResize();
+    window.addEventListener('resize', this._onChartResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this._onChartResize);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/unicorn/app/browser/components/ModelData.jsx
+++ b/unicorn/app/browser/components/ModelData.jsx
@@ -246,10 +246,14 @@ function xScaleCalculate(context, g) {
   let {modelData} = context.props;
 
   if (modelData.data.length) {
+    let data = modelData.data;
+
+    // When there are only a few results, Dygraphs adds some padding.
+    adjusted[0] = Math.max(adjusted[0], data[0][DATA_INDEX_TIME]);
+
     // Must be zoomed out enough that the space is filled with anomaly bars.
     let anomalyBarCount = g.getArea().w / ANOMALY_BAR_WIDTH;
     let minSpread = context._minTimeDelta * anomalyBarCount;
-    let data = modelData.data;
     let discrepancy = minSpread - (adjusted[1] - adjusted[0]);
     if (discrepancy > 0) {
       adjusted[1] = Math.min(data[data.length-1][DATA_INDEX_TIME],
@@ -258,6 +262,11 @@ function xScaleCalculate(context, g) {
       if (discrepancy > 0) {
         adjusted[0] = Math.max(data[0][DATA_INDEX_TIME],
                                adjusted[0] - discrepancy);
+        discrepancy = minSpread - (adjusted[1] - adjusted[0]);
+        if (discrepancy > 0) {
+          // Now force extra space to the right.
+          adjusted[1] += discrepancy;
+        }
       }
     }
   }
@@ -604,8 +613,8 @@ export default class ModelData extends React.Component {
     }
 
     const rawDataInBackground = (modelData.data.length &&
-    model.aggregated &&
-    showNonAgg);
+                                 model.aggregated &&
+                                 showNonAgg);
 
     // Calculate axes, labels, and series. Grab them from the "value" options,
     // maybe insert the "raw" options, then overwrite the actual "options" that

--- a/unicorn/app/browser/lib/Dygraphs/AnomalyBarChartUnderlay.js
+++ b/unicorn/app/browser/lib/Dygraphs/AnomalyBarChartUnderlay.js
@@ -32,16 +32,16 @@ const PADDING = 3;
 
 /**
  * Helper function to Draw a rectangle on a DyGraphs canvas.
- * @param {Object} canvas - Dygraphs Canvas DOM reference.
+ * @param {CanvasRenderingContext2D} ctx - Dygraphs Canvas context.
  * @param {Number} xStart - Starting X coordinate of rectangle.
  * @param {Number} yStart - Starting Y coordinate for rectangle.
  * @param {Number} width - Width of rectangle.
  * @param {Number} height - Height of rectangle.
  * @param {String} color - Color to fill in rectangle.
  */
-function _drawRectangle(canvas, xStart, yStart, width, height, color) {
-  canvas.fillStyle = new RGBColor(color).toRGB();
-  canvas.fillRect(xStart, yStart, width, height);
+function _drawRectangle(ctx, xStart, yStart, width, height, color) {
+  ctx.fillStyle = new RGBColor(color).toRGB();
+  ctx.fillRect(xStart, yStart, width, height);
 }
 
 /**
@@ -65,13 +65,13 @@ function _compare(current, key) {
  *  of a y3 axes, instead of a full custom plugin. Model Result data is forced
  *  in via the Dygraph.option with the key "modelData".
  * @param {Object} context - ModelData.jsx component context w/settings.
- * @param {Object} canvas - DOM Canvas object to draw with, from Dygraphs.
+ * @param {CanvasRenderingContext2D} canvasCtx - Dygraphs Canvas context.
  * @param {Object} area - Canvas drawing area metadata, Width x Height info etc.
  * @param {Object} dygraph - Instantiated Dygraph library object itself.
  * @requries Dygraphs
  * @see view-source:http://dygraphs.com/tests/underlay-callback.html
  */
-export default function (context, canvas, area, dygraph) {
+export default function (context, canvasCtx, area, dygraph) {
   let modelData = dygraph.getOption('modelData') || [];
   if (modelData.length < 2) {
     // Not enough data
@@ -81,7 +81,7 @@ export default function (context, canvas, area, dygraph) {
   // Divide the x extent into buckets.
   // Each bucket contains zero or more points.
   let timespan = dygraph.xAxisRange();
-  let visibleBucketCount = area.w / ANOMALY_BAR_WIDTH;
+  let visibleBucketCount = canvasCtx.canvas.offsetWidth / ANOMALY_BAR_WIDTH;
   let timestampBucketWidth =
         (timespan[1] - timespan[0]) / visibleBucketCount;
   let bucketStart0 =
@@ -135,7 +135,7 @@ export default function (context, canvas, area, dygraph) {
       let x = dygraph.toDomXCoord(bucketStart);
       let y = area.h - 1;
       let height = heightPercent * area.h;
-      _drawRectangle(canvas, x + PADDING/2, y, ANOMALY_BAR_WIDTH - PADDING,
+      _drawRectangle(canvasCtx, x + PADDING/2, y, ANOMALY_BAR_WIDTH - PADDING,
                      -height, color);
     }
 

--- a/unicorn/app/browser/lib/Dygraphs/AnomalyBarChartUnderlay.js
+++ b/unicorn/app/browser/lib/Dygraphs/AnomalyBarChartUnderlay.js
@@ -92,6 +92,7 @@ export default function (context, canvas, area, dygraph) {
   // Walk all of the visible buckets, using a single `iData` index.
   let bucketIndex = firstVisibleBucket;
   let bucketStart = bucketStart0 + (bucketIndex * timestampBucketWidth);
+
   let iData = binarySearch(modelData, timespan[0], _compare);
   if (iData < 0) {
     iData = ~iData;
@@ -100,7 +101,13 @@ export default function (context, canvas, area, dygraph) {
   while (bucketStart <= timespan[1]) {
     // Find all results within this bucket.
     let bucketEnd = bucketStart + timestampBucketWidth;
+
     let matchStart = iData;
+    while (matchStart < modelData.length &&
+           modelData[matchStart][DATA_INDEX_TIME].getTime() < bucketStart) {
+      matchStart++;
+    }
+
     let matchEnd = matchStart;
     while (matchEnd < modelData.length &&
            modelData[matchEnd][DATA_INDEX_TIME].getTime() < bucketEnd) {

--- a/unicorn/app/browser/lib/Dygraphs/CustomDygraph.js
+++ b/unicorn/app/browser/lib/Dygraphs/CustomDygraph.js
@@ -51,7 +51,7 @@ CustomDygraph.prototype.drawGraph_ = function () {
     // approach causes flickering in the range finder, but it avoids flickering
     // in the chart.
     setTimeout(() => {
-      this.updateOptions({dateWindow: adjusted});
+      this.updateOptions({dateWindow: [adjusted[0], adjusted[1]]});
     });
   } else {
     let yExtentAdjusted = this.yAxisRangeCalculate_(this);

--- a/unicorn/app/browser/lib/Dygraphs/CustomDygraph.js
+++ b/unicorn/app/browser/lib/Dygraphs/CustomDygraph.js
@@ -18,37 +18,55 @@
 import Dygraph from 'dygraphs';
 
 /**
- * Add a feature to Dygraphs: allow custom y scaling on each draw.
+ * Add features to Dygraphs:
+ *
+ * - allow custom y scaling on each draw.
+ * - get some control over the dateWindow as it changes. This allows us to
+     implement a max zoom level, though it's still not a great experience.
  *
  * @param {Element} element - param for Dygraph constructor
  * @param {Array} data - param for Dygraph constructor
  * @param {Object} options - param for Dygraph constructor
+ * @param {Function} xAxisRangeCalculate - takes a dygraph
+ *                                         returns a [min, max] x axis range
  * @param {Function} yAxisRangeCalculate - takes a dygraph
  *                                         returns a [min, max] y axis range
  */
-function CustomDygraph(element, data, options, yAxisRangeCalculate) {
+function CustomDygraph(element, data, options, xAxisRangeCalculate,
+                       yAxisRangeCalculate) {
   // This code uses prototype syntax rather than class syntax because it needs
-  // to set `this.yAxisRangeCalculate_` before calling the Dygraph constructor,
-  // which isn't possible with class syntax.
+  // to set these callbacks before calling the Dygraph constructor, which isn't
+  // possible with class syntax.
+  this.xAxisRangeCalculate_ = xAxisRangeCalculate;
   this.yAxisRangeCalculate_ = yAxisRangeCalculate;
   Dygraph.call(this, element, data, options);
 }
 
 CustomDygraph.prototype = Object.create(Dygraph.prototype);
 CustomDygraph.prototype.drawGraph_ = function () {
-  let yExtentAdjusted = this.yAxisRangeCalculate_(this);
+  let dateWindow = this.xAxisRangeCalculate_(this);
+  if (this.dateWindow_[0] !== dateWindow[0] ||
+      this.dateWindow_[1] !== dateWindow[1]) {
+    // Cancel this draw. Schedule another with an allowed date window. This
+    // approach causes flickering in the range finder, but it avoids flickering
+    // in the chart.
+    setTimeout(() => {
+      this.updateOptions({dateWindow});
+    });
+  } else {
+    let yExtentAdjusted = this.yAxisRangeCalculate_(this);
+    // Change it directly. Using `updateOptions` won't work. If it causes a
+    // redraw, there's a stack overflow. With blockRedraw=true, it doesn't
+    // update the axes. Avoid using a valueRange in the options if you're using
+    // a CustomDygraph.
+    this.axes_[0].valueRange = yExtentAdjusted;
+    this.axes_[0].computedValueRange = yExtentAdjusted;
+    this.axes_[0].extremeRange = yExtentAdjusted.map(
+      (v) => v - yExtentAdjusted[0]
+    );
 
-  // Change it directly. Using `updateOptions` won't work. If it causes a
-  // redraw, there's a stack overflow. With blockRedraw=true, it doesn't update
-  // the axes. Avoid using a valueRange in the options if you're using a
-  // CustomDygraph.
-  this.axes_[0].valueRange = yExtentAdjusted;
-  this.axes_[0].computedValueRange = yExtentAdjusted;
-  this.axes_[0].extremeRange = yExtentAdjusted.map(
-    (v) => v - yExtentAdjusted[0]
-  );
-
-  Dygraph.prototype.drawGraph_.call(this);
+    Dygraph.prototype.drawGraph_.call(this);
+  }
 };
 
 export default CustomDygraph;

--- a/unicorn/app/browser/lib/Dygraphs/CustomDygraph.js
+++ b/unicorn/app/browser/lib/Dygraphs/CustomDygraph.js
@@ -44,14 +44,14 @@ function CustomDygraph(element, data, options, xAxisRangeCalculate,
 
 CustomDygraph.prototype = Object.create(Dygraph.prototype);
 CustomDygraph.prototype.drawGraph_ = function () {
-  let dateWindow = this.xAxisRangeCalculate_(this);
-  if (this.dateWindow_[0] !== dateWindow[0] ||
-      this.dateWindow_[1] !== dateWindow[1]) {
+  let original = this.xAxisRange();
+  let adjusted = this.xAxisRangeCalculate_(this);
+  if (original[0] !== adjusted[0] || original[1] !== adjusted[1]) {
     // Cancel this draw. Schedule another with an allowed date window. This
     // approach causes flickering in the range finder, but it avoids flickering
     // in the chart.
     setTimeout(() => {
-      this.updateOptions({dateWindow});
+      this.updateOptions({dateWindow: adjusted});
     });
   } else {
     let yExtentAdjusted = this.yAxisRangeCalculate_(this);


### PR DESCRIPTION
Calculating in terms of "pointsPerBar" only works in some cases. It doesn't always work, e.g if there are gaps in the time series.

The new way of thinking: Split the timeline into equal-width buckets, based on the zoom level, and draw 0 or 1 anomaly bars per bucket.

This solves the general problem of collapsing anomaly bars into each other. For example, previously with non-aggregated data the anomaly bars would sometimes collide. Now they'll collapse into each other rather than collide.

@marionleborgne @lscheinkman 

This doesn't solve:

- Dygraphs doesn't let us set a "zoom limit", so on small data sets, you can zoom in further than we'd like users to zoom in.
  - We might be able to solve this by adding another feature to Dygraphs via our new CustomDygraphs class.
  - Or we could have our AnomalyBarChartUnderlay change the zoom and force a redraw when it notices a small zoom. But this will make the experience pretty janky. A draw shouldn't queue a redraw.
- Dygraphs sets its own "zoom limit" just based on the range selector size, so on large data sets you can't zoom in far enough to see one anomaly bar per point. In general with HTM Studio you'll see more points than anomaly bars.
  - You can see this in the Dygraphs demos: http://dygraphs.com/tests/range-selector.html  The zoom limit is set by the size of the range finder.
  - We could probably force a smaller zoom programmatically, and we could make this one of the blue links at the top.