### PR TITLE
Fix model results summary

### DIFF
--- a/unicorn/app/browser/actions/StartModel.js
+++ b/unicorn/app/browser/actions/StartModel.js
@@ -34,6 +34,9 @@ export default function (actionContext, payload) {
     let {aggOpts, inputOpts, metricId, modelOpts} = payload;
     let aggregated = (Object.keys(aggOpts).length >= 1);
 
+    // Update metricStore
+    actionContext.dispatch(ACTIONS.UPDATE_METRIC, payload);
+
     // Save to database
     let db = actionContext.getDatabaseClient();
     return promisify(::db.updateMetric, metricId, {

--- a/unicorn/app/browser/lib/Constants.js
+++ b/unicorn/app/browser/lib/Constants.js
@@ -42,6 +42,7 @@ Object.assign(module.exports, CommonConstants);
  * - Metric
  *  - LIST_METRICS: {@link ListMetrics}
  *  - LIST_METRICS_FAILURE
+ *  - UPDATE_METRIC: {@link UpdateMetric}
  *
  * - Metric Data
  *  - LOAD_METRIC_DATA: {@link LoadMetricData}
@@ -112,6 +113,7 @@ export const ACTIONS = Object.freeze({
   // Metric
   LIST_METRICS: 'LIST_METRICS',
   LIST_METRICS_FAILURE: 'LIST_METRICS_FAILURE',
+  UPDATE_METRIC: 'UPDATE_METRIC',
 
   // Metric Data
   LOAD_METRIC_DATA: 'LOAD_METRIC_DATA',

--- a/unicorn/app/browser/stores/MetricStore.js
+++ b/unicorn/app/browser/stores/MetricStore.js
@@ -59,6 +59,7 @@ export default class MetricStore extends BaseStore {
     return {
       DELETE_FILE: '_handleDeleteFile',
       LIST_METRICS: '_handleListMetrics',
+      UPDATE_METRIC: '_handleUpdateMetric',
       CHART_UPDATE_VIEWPOINT: '_handleUpdateViewpoint'
     }
   }
@@ -142,6 +143,23 @@ export default class MetricStore extends BaseStore {
         }
         this._metrics.set(metric.uid, record);
       });
+      this.emitChange();
+    }
+  }
+
+  /**
+   * Update store metric
+   * @param  {Object} payload - metric info to update in the store
+   */
+  _handleUpdateMetric(payload) {
+    let {aggOpts, inputOpts, metricId, modelOpts} = payload;
+
+    let metric = this._metrics.get(metricId);
+    if (metric) {
+      metric.aggregation_options = aggOpts;
+      metric.input_options = inputOpts;
+      metric.model_options = modelOpts;
+
       this.emitChange();
     }
   }


### PR DESCRIPTION
Problem 
* The HTM Settings at the bottom of the model summary dialog were incorrect. Except after you refresh the app.

Solution:
* This is happened because the DB was updated but not the metricStore - when the model is started.
* The fix consisted in dispatching an action to update the metricStore with param finder results for the specific model/metric that is started.

cc @mrcslws @lscheinkman 