### PR TITLE
Updated native menus

### DIFF
--- a/unicorn/README.md
+++ b/unicorn/README.md
@@ -478,5 +478,6 @@ does [not yet work with Electron](https://github.com/atom/electron/issues/915).
 ## How to create a release?
 
 * Create a branch called "htm-studio-vX" where X is the version number
+* Update `app/package.json` with new version number
 * The convention for version numbers is [semantic versioning](http://semver.org/)
 * For example, we have a branch called [`htm-studio-v0.0.1`](https://github.com/numenta/numenta-apps/tree/htm-studio-v0.0.1)

--- a/unicorn/README.md
+++ b/unicorn/README.md
@@ -472,3 +472,11 @@ does [not yet work with Electron](https://github.com/atom/electron/issues/915).
 ### Other
 
 * [Electron and Windows Debug Symbol Server](http://electron.atom.io/docs/v0.31.0/development/setting-up-symbol-server/)
+
+# Release management
+
+## How to create a release?
+
+* Create a branch called "htm-studio-vX" where X is the version number
+* The convention for version numbers is [semantic versioning](http://semver.org/)
+* For example, we have a branch called [`htm-studio-v0.0.1`](https://github.com/numenta/numenta-apps/tree/htm-studio-v0.0.1)

--- a/unicorn/app/browser/about.html
+++ b/unicorn/app/browser/about.html
@@ -31,28 +31,17 @@
     <p>Version <span id="version"></span></p>
     <p>Copyright © 2016 Numenta</p>
     <p>All rights reserved.</p>
-    <p>License:
-        <a href="#"
-           onclick="electron.shell.openExternal('https://raw.githubusercontent.com/numenta/numenta-apps/master/unicorn/LICENSE.txt');">
-            AGPLv3
-        </a>
-    </p>
     <p>
         <a href="#"
            onclick="electron.shell.openExternal('http://numenta.com/htm-studio/?terms=1');">
-            Terms and Conditions
+            License
         </a>
     </p>
 </div>
 
 <script type="text/javascript">
-    var xhr = new XMLHttpRequest();
-    xhr.addEventListener('load', function () {
-        var data = JSON.parse(this.responseText);
-        document.getElementById('version').textContent = data.version;
-    });
-    xhr.open('GET', './../package.json');
-    xhr.send();
+    var package_json = require('../package.json');
+    document.getElementById('version').textContent = package_json.version
 </script>
 </body>
 </html>

--- a/unicorn/app/browser/about.html
+++ b/unicorn/app/browser/about.html
@@ -1,39 +1,58 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
+<head>
+    <meta charset="utf-8"/>
     <style type="text/css">
-      body {
-        background-color: #ECECEC;
-        font-family: Verdana;
-      }
+        body {
+            background-color: #ECECEC;
+            font-family: sans-serif;
+        }
 
-      .bold {
-        font-weight:bold;
-      }
+        .bold {
+            font-weight: bold;
+        }
 
-      .medium {
-        font-size:14px;
-      }
+        .medium {
+            font-size: 14px;
+        }
 
-      .small {
-        font-size:11px;
-      }
+        .small {
+            font-size: 11px;
+        }
     </style>
     <script type="text/javascript">
-      let electron = require('electron');
+        let electron = require('electron');
     </script>
-  </head>
-  <body>
-    <div style="text-align:center;">
-      <img src="assets/images/icon-512.png" width="64" />
-      <p class="medium bold" style="margin-top:10px;">HTM Studio</p>
-      <p class="small">Version 0.1</p>
-      <p class="small">Copyright © 2016 Numenta<br />
-        All rights reserved.</p>
-      <p class="small"><a href="#"
-         onclick="electron.shell.openExternal('https://raw.githubusercontent.com/numenta/numenta-apps/master/unicorn/LICENSE.txt');">
-        License</a></p>
-    </div>
-  </body>
+</head>
+<body>
+<div style="margin-top: 15px; text-align:center;" class="small">
+    <img src="assets/images/icon-512.png" width="40"/>
+    <p class="medium bold" style="margin-top:10px;">HTM Studio</p>
+    <p>Version <span id="version"></span></p>
+    <p>Copyright © 2016 Numenta</p>
+    <p>All rights reserved.</p>
+    <p>License:
+        <a href="#"
+           onclick="electron.shell.openExternal('https://raw.githubusercontent.com/numenta/numenta-apps/master/unicorn/LICENSE.txt');">
+            AGPLv3
+        </a>
+    </p>
+    <p>
+        <a href="#"
+           onclick="electron.shell.openExternal('http://numenta.com/htm-studio/?terms=1');">
+            Terms and Conditions
+        </a>
+    </p>
+</div>
+
+<script type="text/javascript">
+    var xhr = new XMLHttpRequest();
+    xhr.addEventListener('load', function () {
+        var data = JSON.parse(this.responseText);
+        document.getElementById('version').textContent = data.version;
+    });
+    xhr.open('GET', './../package.json');
+    xhr.send();
+</script>
+</body>
 </html>

--- a/unicorn/app/main/MainMenu.js
+++ b/unicorn/app/main/MainMenu.js
@@ -32,7 +32,7 @@ if (aboutMenuItem.label === 'About HTM Studio') {
   // Do this instead.
   aboutMenuItem.click = () => {
     const BrowserWindow = electron.BrowserWindow;
-    let win = new BrowserWindow({width: 283, height: 250, title: ''});
+    let win = new BrowserWindow({width: 283, height: 230, title: ''});
     win.loadURL(`file://${__dirname}/../browser/about.html`);
   };
 } else {

--- a/unicorn/app/main/MainMenu.js
+++ b/unicorn/app/main/MainMenu.js
@@ -32,7 +32,7 @@ if (aboutMenuItem.label === 'About HTM Studio') {
   // Do this instead.
   aboutMenuItem.click = () => {
     const BrowserWindow = electron.BrowserWindow;
-    let win = new BrowserWindow({width: 283, height: 234, title: ''});
+    let win = new BrowserWindow({width: 283, height: 250, title: ''});
     win.loadURL(`file://${__dirname}/../browser/about.html`);
   };
 } else {
@@ -43,26 +43,36 @@ if (aboutMenuItem.label === 'About HTM Studio') {
 
 let helpMenu = menu.find((item) => item.label === 'Help');
 if (helpMenu) {
+  // Learn More
+  helpMenu.submenu.splice(0, 1); // Remove old behavior
   helpMenu.submenu.push({
-    label: 'Provide Feedback',
+    label: 'Lean More',
     click() {
-      let url = 'http://numenta.com/?HTM_STUDIO_FEEDBACK_PLACEHOLDER';
+      let url = 'http://numenta.com/htm-studio';
       electron.shell.openExternal(url);
     }
   });
+
+  // FAQ
+  helpMenu.submenu.push({
+    label: 'Frequently Asked Questions',
+    click() {
+      let url = 'http://numenta.com/htm-studio#faq';
+      electron.shell.openExternal(url);
+    }
+  });
+
+  // Provide Feedback
+  helpMenu.submenu.push({
+    label: 'Provide Feedback',
+    click() {
+      let url = 'http://numenta.com/htm-studio#feedback';
+      electron.shell.openExternal(url);
+    }
+  });
+
 } else {
   throw new Error('Could not find Help menu.');
 }
-
-menu.splice(1, 0, {
-  label: 'File',
-  submenu: [
-    {
-      label: 'Open File...',
-      accelerator: 'Command+O',
-      role: 'open'
-    }
-  ]
-});
 
 export default menu;

--- a/unicorn/app/package.json
+++ b/unicorn/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "htmstudio",
   "productName": "HTM Studio",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Numenta HTM Studio Cross-platform HTM Example Desktop Application",
   "main": "main/loader.js",
   "private": true,


### PR DESCRIPTION
Updated URLs:
* HTM Studio: http://numenta.com/htm-studio/
* EULA Terms: http://numenta.com/htm-studio/?terms=1
* Feedback Form: http://numenta.com/htm-studio/#feedback
* FAQ anchor: http://numenta.com/htm-studio/#faq

Other changes:
* Pull version number from `app/package.json`
* Updated behavior of "Learn More" submenu (points to http://numenta.com/htm-studio/)
* Removed "File" menu which did not work
* Versioning documentation