### PR TITLE
UNI-444: Shrink portable python distribution  

### DIFF
--- a/unicorn/app/package.json
+++ b/unicorn/app/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "babel-core": "6.7.2",
-    "babel-eslint": "4.1.8",
     "babel-loader": "6.2.4",
     "babel-plugin-add-module-exports": "0.1.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/unicorn/scripts/OSX/build-python.sh
+++ b/unicorn/scripts/OSX/build-python.sh
@@ -115,6 +115,8 @@ git clone https://github.com/numenta/nupic.git
 
 echo "==> Installing nupic ..."
 pushd $NUPIC
+# Clean up nupic  datafiles
+rm -rf datafiles
 $PREFIX/bin/pip install -r external/common/requirements.txt --no-cache-dir
 $PREFIX/bin/python setup.py install
 popd
@@ -128,6 +130,24 @@ rm -rf $NUPIC_CORE
 echo "--> Removed: $NUPIC_CORE"
 rm -rf $NUPIC
 echo "--> Removed: $NUPIC"
+
+# Clean up miniconda
+$PREFIX/bin/python $PREFIX/bin/conda clean --packages --source-cache --index-cache --tarballs --lock -y
+
+# Remove development headers
+rm -fr $PREFIX/include
+
+# Remove python sources
+find $PREFIX -name "*.py" -delete
+
+# Remove test binaries
+rm $PREFIX/bin/*test
+rm $PREFIX/bin/*tests
+rm $PREFIX/bin/hello*
+
+# Remove development binaries
+rm $PREFIX/bin/capnp*
+rm $PREFIX/lib/libnupic_core.a
 
 # Check that it worked
 $PREFIX/bin/python -c "import nupic.algorithms.anomaly_likelihood"

--- a/unicorn/scripts/OSX/build-python.sh
+++ b/unicorn/scripts/OSX/build-python.sh
@@ -116,7 +116,7 @@ git clone https://github.com/numenta/nupic.git
 echo "==> Installing nupic ..."
 pushd $NUPIC
 # Clean up nupic  datafiles
-rm -rf datafiles
+rm -rf src/nupic/datafiles
 $PREFIX/bin/pip install -r external/common/requirements.txt --no-cache-dir
 $PREFIX/bin/python setup.py install
 popd
@@ -130,24 +130,6 @@ rm -rf $NUPIC_CORE
 echo "--> Removed: $NUPIC_CORE"
 rm -rf $NUPIC
 echo "--> Removed: $NUPIC"
-
-# Clean up miniconda
-$PREFIX/bin/python $PREFIX/bin/conda clean --packages --source-cache --index-cache --tarballs --lock -y
-
-# Remove development headers
-rm -fr $PREFIX/include
-
-# Remove python sources
-find $PREFIX -name "*.py" -delete
-
-# Remove test binaries
-rm $PREFIX/bin/*test
-rm $PREFIX/bin/*tests
-rm $PREFIX/bin/hello*
-
-# Remove development binaries
-rm $PREFIX/bin/capnp*
-rm $PREFIX/lib/libnupic_core.a
 
 # Check that it worked
 $PREFIX/bin/python -c "import nupic.algorithms.anomaly_likelihood"
@@ -163,6 +145,25 @@ cp -RL $PREFIX $PREFIX.npm
 rm -rf $PREFIX
 
 pushd $PREFIX.npm
+
+# Clean up miniconda
+./bin/python ./bin/conda clean --packages --source-cache --index-cache --tarballs --lock -y
+
+# Remove development headers
+rm -fr ./include
+
+# Remove python sources
+find . -name "*.py" -delete
+
+# Remove test binaries
+rm ./bin/*test
+rm ./bin/*tests
+rm ./bin/hello*
+
+# Remove development binaries
+rm ./bin/capnp*
+rm ./lib/libnupic_core.a
+
 # Copy NPM package information
 cp ${SCRIPT_PATH}/index.js .
 cp ${SCRIPT_PATH}/package.json .

--- a/unicorn/webpack.config.babel.js
+++ b/unicorn/webpack.config.babel.js
@@ -20,7 +20,6 @@
  */
 export default {
   bail: true,
-  devtool: 'source-map',
   entry: ['babel-polyfill', './app/browser/entry'],
   module: {
     loaders: [


### PR DESCRIPTION
@marionleborgne Here are the new DMG file size
```
125M	HTM Studio-0.0.1-mac.zip
107M	HTM Studio-0.0.1.dmg
```

The application size is still large but it was reduced by 300M:
```
348M	HTM Studio.app
```

To reduce the application size further we would need to dig deeper into electron's and python's dependencies. 

Here is `electron` dependency size:
```
106M	HTM Studio.app/Contents/Frameworks
```

Here are the top 10 dependencies `node_modules` sizes:
```
136M	HTM Studio.app/Contents/Resources/app/node_modules/portable_python_darwin
 13M	HTM Studio.app/Contents/Resources/app/node_modules/roboto-fontface
 10M	HTM Studio.app/Contents/Resources/app/node_modules/dygraphs
9.7M	HTM Studio.app/Contents/Resources/app/node_modules/material-ui
7.6M	HTM Studio.app/Contents/Resources/app/node_modules/fsevents
6.6M	HTM Studio.app/Contents/Resources/app/node_modules/core-js
5.3M	HTM Studio.app/Contents/Resources/app/node_modules/babel-runtime
4.8M	HTM Studio.app/Contents/Resources/app/node_modules/fbjs
4.7M	HTM Studio.app/Contents/Resources/app/node_modules/react-tap-event-plugin
4.4M	HTM Studio.app/Contents/Resources/app/node_modules/lodash
```

cc: @cbaranski 

