### PR TITLE
UNI-490: HTM Studio drop down menus 

### DIFF
--- a/unicorn/app/browser/about.html
+++ b/unicorn/app/browser/about.html
@@ -34,7 +34,7 @@
     <p>
         <a href="#"
            onclick="electron.shell.openExternal('http://numenta.com/htm-studio/?terms=1');">
-            License
+            Terms and Conditions
         </a>
     </p>
 </div>

--- a/unicorn/app/browser/about.html
+++ b/unicorn/app/browser/about.html
@@ -32,7 +32,7 @@
     <p>Copyright © 2016 Numenta</p>
     <p>All rights reserved.</p>
     <p>
-        <a href="#"
+        <a href=""
            onclick="electron.shell.openExternal('http://numenta.com/htm-studio/?terms=1');">
             Terms and Conditions
         </a>

--- a/unicorn/app/main/MainMenu.js
+++ b/unicorn/app/main/MainMenu.js
@@ -21,6 +21,7 @@
 
 const electron = require('electron');
 const name = electron.app.getName();
+const VERSION = require('../package.json').version;
 
 let crossPlatformMenu = [
   {
@@ -77,7 +78,10 @@ let crossPlatformMenu = [
       {
         label: 'Report Bug',
         click() {
-          let url = 'http://github.com/numenta/numenta-apps/issues/new';
+          let url = `mailto:htm-studio@numenta.com?
+          subject=HTM Studio ${VERSION} bug
+          &body=DO NOT REMOVE THIS INFORMATION: HTM Studio version ${VERSION}.
+          Please describe the steps to reproduce the bug below: `;
           electron.shell.openExternal(url);
         }
       }

--- a/unicorn/app/main/MainMenu.js
+++ b/unicorn/app/main/MainMenu.js
@@ -21,7 +21,7 @@
 
 const electron = require('electron');
 const name = electron.app.getName();
-const VERSION = require('../package.json').version;
+const VERSION = electron.app.getVersion();
 
 let crossPlatformMenu = [
   {
@@ -78,10 +78,7 @@ let crossPlatformMenu = [
       {
         label: 'Report Bug',
         click() {
-          let url = `mailto:htm-studio@numenta.com?
-          subject=HTM Studio ${VERSION} bug
-          &body=DO NOT REMOVE THIS INFORMATION: HTM Studio version ${VERSION}.
-          Please describe the steps to reproduce the bug below: `;
+          let url = `mailto:htm-studio@numenta.com?subject=HTM Studio ${VERSION} bug&body=DO NOT REMOVE THIS INFORMATION: HTM Studio version ${VERSION}. Please describe the steps to reproduce the bug below. `; // eslint-disable-line
           electron.shell.openExternal(url);
         }
       }

--- a/unicorn/app/main/MainMenu.js
+++ b/unicorn/app/main/MainMenu.js
@@ -15,64 +15,176 @@
 //
 // http://numenta.org/licenses/
 
-import defaultMenu from 'electron-default-menu';
-let electron = require('electron');
-
 /**
  * Main top system menu (File/Open.., etc) for application
  */
 
-let menu = defaultMenu();
+const electron = require('electron');
+const name = electron.app.getName();
 
-let aboutMenuItem = menu[0].submenu[0];
-if (aboutMenuItem.label === 'About HTM Studio') {
-  // Don't show the default Electron dialog.
-  delete aboutMenuItem.role;
+let crossPlatformMenu = [
+  {
+    label: name,
+    submenu: [
+      {
+        label: `About ${name}`,
+        click() {
+          const BrowserWindow = electron.BrowserWindow;
+          let win = new BrowserWindow({width: 283, height: 230, title: ''});
+          win.loadURL(`file://${__dirname}/../browser/about.html`);
+        }
+      }
+    ]
+  },
+  {
+    label: 'View',
+    submenu: [
+      {
+        label: 'Toggle Full Screen',
+        accelerator: process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
+        click(item, focusedWindow) {
+          if (focusedWindow)
+            focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+        }
+      }
+    ]
+  },
+  {
+    label: 'Help',
+    role: 'help',
+    submenu: [
+      {
+        label: 'Learn More',
+        click() {
+          let url = 'http://numenta.com/htm-studio';
+          electron.shell.openExternal(url);
+        }
+      },
+      {
+        label: 'Frequently Asked Questions',
+        click() {
+          let url = 'http://numenta.com/htm-studio#faq';
+          electron.shell.openExternal(url);
+        }
+      },
+      {
+        label: 'Provide Feedback',
+        click() {
+          let url = 'http://numenta.com/htm-studio#feedback';
+          electron.shell.openExternal(url);
+        }
+      },
+      {
+        label: 'Report Bug',
+        click() {
+          let url = 'http://github.com/numenta/numenta-apps/issues/new';
+          electron.shell.openExternal(url);
+        }
+      }
+    ]
+  }
+];
 
-  // Do this instead.
-  aboutMenuItem.click = () => {
-    const BrowserWindow = electron.BrowserWindow;
-    let win = new BrowserWindow({width: 283, height: 230, title: ''});
-    win.loadURL(`file://${__dirname}/../browser/about.html`);
-  };
-} else {
-  throw new Error(
-    `Unexpected menu item in first position: ${aboutMenuItem.label}`
+
+if (process.platform === 'darwin') {
+
+  let aboutMenu = crossPlatformMenu.find((item) => item.label === name);
+
+  aboutMenu.submenu.push(
+    {
+      type: 'separator'
+    },
+    {
+      label: 'Services',
+      role: 'services',
+      submenu: []
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: `Hide ${name}`,
+      accelerator: 'Command+H',
+      role: 'hide'
+    },
+    {
+      label: 'Hide Others',
+      accelerator: 'Command+Alt+H',
+      role: 'hideothers'
+    },
+    {
+      label: 'Show All',
+      role: 'unhide'
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: 'Quit',
+      accelerator: 'Command+Q',
+      click() {
+        electron.app.quit();
+      }
+    }
   );
+
+  const editMenu = {
+    label: 'Edit',
+    submenu: [
+      {
+        label: 'Undo',
+        accelerator: 'CmdOrCtrl+Z',
+        role: 'undo'
+      },
+      {
+        label: 'Redo',
+        accelerator: 'Shift+CmdOrCtrl+Z',
+        role: 'redo'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Cut',
+        accelerator: 'CmdOrCtrl+X',
+        role: 'cut'
+      },
+      {
+        label: 'Copy',
+        accelerator: 'CmdOrCtrl+C',
+        role: 'copy'
+      },
+      {
+        label: 'Paste',
+        accelerator: 'CmdOrCtrl+V',
+        role: 'paste'
+      },
+      {
+        label: 'Select All',
+        accelerator: 'CmdOrCtrl+A',
+        role: 'selectall'
+      }
+    ]
+  };
+
+  const windowMenu = {
+    label: 'Window',
+    role: 'window',
+    submenu: [
+      {
+        label: 'Minimize',
+        accelerator: 'CmdOrCtrl+M',
+        role: 'minimize'
+      },
+      {
+        label: 'Close',
+        accelerator: 'CmdOrCtrl+W',
+        role: 'close'
+      }
+    ]
+  };
+
+  crossPlatformMenu.splice(1, 0, editMenu, windowMenu);
 }
 
-let helpMenu = menu.find((item) => item.label === 'Help');
-if (helpMenu) {
-  // Learn More
-  helpMenu.submenu.splice(0, 1); // Remove old behavior
-  helpMenu.submenu.push({
-    label: 'Lean More',
-    click() {
-      let url = 'http://numenta.com/htm-studio';
-      electron.shell.openExternal(url);
-    }
-  });
-
-  // FAQ
-  helpMenu.submenu.push({
-    label: 'Frequently Asked Questions',
-    click() {
-      let url = 'http://numenta.com/htm-studio#faq';
-      electron.shell.openExternal(url);
-    }
-  });
-
-  // Provide Feedback
-  helpMenu.submenu.push({
-    label: 'Provide Feedback',
-    click() {
-      let url = 'http://numenta.com/htm-studio#feedback';
-      electron.shell.openExternal(url);
-    }
-  });
-
-} else {
-  throw new Error('Could not find Help menu.');
-}
-
-export default menu;
+export default crossPlatformMenu;

--- a/unicorn/app/main/MainMenu.js
+++ b/unicorn/app/main/MainMenu.js
@@ -129,6 +129,7 @@ if (process.platform === 'darwin') {
     }
   );
 
+  // FIXME: UNI-520 - Bring back Edit menu on windows
   const editMenu = {
     label: 'Edit',
     submenu: [

--- a/unicorn/app/package.json
+++ b/unicorn/app/package.json
@@ -60,7 +60,6 @@
     "convert-newline": "0.0.5",
     "csv-streamify": "3.0.3",
     "dygraphs": "1.1.1",
-    "electron-default-menu": "0.1.1",
     "file-api": "0.10.4",
     "fluxible": "1.0.4",
     "fluxible-addons-react": "0.2.6",


### PR DESCRIPTION
Fixes: 
* UNI-490 HTM Studio drop down menus have meaningless/ useless items
* UNI-491 Link in about box should say "Terms and Conditions" not "License"
* UNI-489 About box has extraneous title after clicking license link
* UNI-498 add a "Report bug" submenu 

And should help for the windows build. @oxtopus let me know if this works for you. 