### PR TITLE
UNI-464 removes tooltips on model action buttons

### DIFF
--- a/unicorn/app/browser/components/Model.jsx
+++ b/unicorn/app/browser/components/Model.jsx
@@ -478,7 +478,7 @@ export default class Model extends React.Component {
 
       // Results Action buttons
       actions = (
-        <CardActions style={this._styles.actions}>
+        <CardActions style={this._styles.actions} title="">
           {showNonAggAction}
           <RaisedButton
             label={this._config.get('button:model:summary')}
@@ -507,7 +507,7 @@ export default class Model extends React.Component {
     } else {
       // Create Action buttons
       actions = (
-        <CardActions style={this._styles.actions}>
+        <CardActions style={this._styles.actions} title="">
           <RaisedButton
             primary={true}
             label={this._config.get('button:model:create')}


### PR DESCRIPTION
Removed the tooltips from the action buttons in the model in model.jsx. Bug was due to inheriting the title from the Card.

Please Review @marionleborgne @lscheinkman 