### PR TITLE
UNI-362: Add support for Google Analytics

### DIFF
--- a/unicorn/README.md
+++ b/unicorn/README.md
@@ -430,6 +430,14 @@ The resulting artifacts can be found in `dist/`
   be signed.
 * See [electron-builder#code-signing](https://github.com/electron-userland/electron-builder#code-signing) for more info.
 
+### Google Analytics
+
+* Set the environment variable `GA_TRACKING_ID` with Google Analytics tracking ID. See https://analytics.google.com/analytics for correct ID. It should be something like this:
+
+```shell
+export GA_TRACKING_ID="UA-XXXXXXXX-X"
+```
+
 ### App Store
 
 * Currently, the instructions to release an Electron app on the app store can

--- a/unicorn/app/browser/actions/AddShowModel.js
+++ b/unicorn/app/browser/actions/AddShowModel.js
@@ -33,10 +33,13 @@ import ShowModelAction from './ShowModel';
  * @emits {ADD_MODEL_FAILED}
  */
 export default function (actionContext, model) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.ADD_MODEL);
+
   return new Promise((resolve, reject) => {
     let db = actionContext.getDatabaseClient();
     db.putModel(model, (error) => {
       if (error) {
+        actionContext.getGATracker().exception(ACTIONS.ADD_MODEL_FAILED);
         actionContext.dispatch(ACTIONS.ADD_MODEL_FAILED, {error, model});
         reject(error);
       } else {

--- a/unicorn/app/browser/actions/DeleteFile.js
+++ b/unicorn/app/browser/actions/DeleteFile.js
@@ -29,11 +29,14 @@ import {ACTIONS} from '../lib/Constants';
  * @return {Promise}
  */
 export default function (actionContext, filename) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.DELETE_FILE);
+
   return new Promise((resolve, reject) => {
     let database = actionContext.getDatabaseClient();
     // Delete file and its data
     database.deleteFile(filename, (error) => {
       if (error) {
+        actionContext.getGATracker().exception(ACTIONS.DELETE_FILE_FAILED);
         actionContext.dispatch(ACTIONS.DELETE_FILE_FAILED, {filename, error});
         reject(error);
       } else {

--- a/unicorn/app/browser/actions/DeleteModel.js
+++ b/unicorn/app/browser/actions/DeleteModel.js
@@ -28,11 +28,14 @@ import {ACTIONS} from '../lib/Constants';
  * @return {Promise}
  */
 export default function (actionContext, modelId) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.DELETE_MODEL);
+
   return new Promise((resolve, reject) => {
     let database = actionContext.getDatabaseClient();
     // Delete model
     database.deleteModel(modelId, (error) => {
       if (error) {
+        actionContext.getGATracker().exception(ACTIONS.DELETE_MODEL_FAILED);
         actionContext.dispatch(ACTIONS.DELETE_MODEL_FAILED, {modelId, error});
         reject(error);
       } else {

--- a/unicorn/app/browser/actions/ExportModelResults.js
+++ b/unicorn/app/browser/actions/ExportModelResults.js
@@ -30,12 +30,15 @@ import {ACTIONS, PROBATION_LENGTH} from '../lib/Constants';
  * @return {Promise} - Promise to resolve when data is loaded
  */
 export default function (actionContext, payload) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.EXPORT_MODEL_RESULTS);
+
   return new Promise((resolve, reject) => {
     let {modelId, filename, timestampFormat} = payload;
     let database = actionContext.getDatabaseClient();
     database.exportModelData(
       modelId, filename, timestampFormat, PROBATION_LENGTH, (error) => {
         if (error) {
+          actionContext.getGATracker().exception(ACTIONS.EXPORT_MODEL_RESULTS_FAILED); // eslint-disable-line
           actionContext.dispatch(ACTIONS.EXPORT_MODEL_RESULTS_FAILED, error);
           reject(error);
         } else {

--- a/unicorn/app/browser/actions/FileUpdate.js
+++ b/unicorn/app/browser/actions/FileUpdate.js
@@ -28,10 +28,13 @@ import {ACTIONS} from '../lib/Constants';
  * @return {Promise}
  */
 export default function (actionContext, file) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.UPDATE_FILE);
+
   return new Promise((resolve, reject) => {
     let db = actionContext.getDatabaseClient();
     db.putFile(file, (error, results) => {
       if (error) {
+        actionContext.getGATracker().exception(ACTIONS.UPDATE_FILE_FAILED);
         actionContext.dispatch(ACTIONS.UPDATE_FILE_FAILED, file);
         reject(error);
       } else {

--- a/unicorn/app/browser/actions/FileUpload.js
+++ b/unicorn/app/browser/actions/FileUpload.js
@@ -26,10 +26,13 @@ import ListMetricsAction from '../actions/ListMetrics';
  * @return {Promise}  Promise
  */
 export default function (actionContext, filename) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.UPLOADED_FILE);
+
   return new Promise((resolve, reject) => {
     let db = actionContext.getDatabaseClient();
     db.uploadFile(filename, (error, file) => {
       if (error) {
+        actionContext.getGATracker().exception(ACTIONS.UPLOADED_FILE_FAILED);
         actionContext.dispatch(ACTIONS.UPLOADED_FILE_FAILED, error);
         reject(error);
       } else {

--- a/unicorn/app/browser/actions/FileValidate.js
+++ b/unicorn/app/browser/actions/FileValidate.js
@@ -25,10 +25,13 @@ import {ACTIONS} from '../lib/Constants';
  * @return {Promise}
  */
 export default function (actionContext, filename) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.VALIDATE_FILE);
+
   return new Promise((resolve, reject) => {
     let fs = actionContext.getFileClient();
     fs.validate(filename, (error, results) => {
       if (error) {
+        actionContext.getGATracker().exception(ACTIONS.VALIDATE_FILE_FAILED);
         actionContext.dispatch(ACTIONS.VALIDATE_FILE_FAILED, {
           error, ...results
         });

--- a/unicorn/app/browser/actions/HideCreateModelDialog.js
+++ b/unicorn/app/browser/actions/HideCreateModelDialog.js
@@ -24,5 +24,7 @@ import {ACTIONS} from '../lib/Constants';
  * @emits {HIDE_CREATE_MODEL_DIALOG}
  */
 export default function (actionContext) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.HIDE_CREATE_MODEL_DIALOG);
+
   actionContext.dispatch(ACTIONS.HIDE_CREATE_MODEL_DIALOG);
 }

--- a/unicorn/app/browser/actions/HideFileDetails.js
+++ b/unicorn/app/browser/actions/HideFileDetails.js
@@ -25,5 +25,7 @@ import {ACTIONS} from '../lib/Constants';
  * @emits {HIDE_FILE_DETAILS}
  */
 export default function (actionContext) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.HIDE_FILE_DETAILS);
+
   actionContext.dispatch(ACTIONS.HIDE_FILE_DETAILS);
 }

--- a/unicorn/app/browser/actions/HideModel.js
+++ b/unicorn/app/browser/actions/HideModel.js
@@ -27,5 +27,6 @@ import {ACTIONS} from '../lib/Constants';
  * @see http://fluxible.io/api/actions.html#api-code-actions-code-
  */
 export default function (actionContext, modelId) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.HIDE_MODEL);
   actionContext.dispatch(ACTIONS.HIDE_MODEL, modelId);
 }

--- a/unicorn/app/browser/actions/ModelError.js
+++ b/unicorn/app/browser/actions/ModelError.js
@@ -33,16 +33,19 @@ export default function (actionContext, payload) {
   let {command, modelId, error} = payload;
 
   if (command === 'create') {
+    actionContext.getGATracker().exception(ACTIONS.START_MODEL_FAILED);
     actionContext.dispatch(ACTIONS.START_MODEL_FAILED, {
       modelId, error
     });
     return;
   } else if (command === 'remove') {
+    actionContext.getGATracker().exception(ACTIONS.STOP_MODEL_FAILED);
     actionContext.dispatch(ACTIONS.STOP_MODEL_FAILED, {
       modelId, error
     });
     return;
   }
+  actionContext.getGATracker().exception(ACTIONS.UNKNOWN_MODEL_FAILURE);
   actionContext.dispatch(ACTIONS.UNKNOWN_MODEL_FAILURE, {
     modelId, error
   });

--- a/unicorn/app/browser/actions/OverrideParamFinderResults.js
+++ b/unicorn/app/browser/actions/OverrideParamFinderResults.js
@@ -26,5 +26,6 @@ import {ACTIONS} from '../lib/Constants';
  * @emits {OVERRIDE_PARAM_FINDER_RESULTS}
  */
 export default function (actionContext, payload) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.OVERRIDE_PARAM_FINDER_RESULTS); // eslint-disable-line
   actionContext.dispatch(ACTIONS.OVERRIDE_PARAM_FINDER_RESULTS, payload);
 }

--- a/unicorn/app/browser/actions/ParamFinderError.js
+++ b/unicorn/app/browser/actions/ParamFinderError.js
@@ -32,17 +32,20 @@ import {ACTIONS} from '../lib/Constants';
 export default function (actionContext, payload) {
   let {command, metricId, error} = payload;
   if (command === 'create') {
+    actionContext.getGATracker().exception(ACTIONS.START_PARAM_FINDER_FAILED);
     actionContext.dispatch(ACTIONS.START_PARAM_FINDER_FAILED, {
       metricId, error
     });
     return;
   } else if (command === 'remove') {
+    actionContext.getGATracker().exception(ACTIONS.STOP_PARAM_FINDER_FAILED);
     actionContext.dispatch(ACTIONS.STOP_PARAM_FINDER_FAILED, {
       metricId, error
     });
     return;
   }
 
+  actionContext.getGATracker().exception(ACTIONS.UNKNOWN_PARAM_FINDER_FAILURE);
   actionContext.dispatch(ACTIONS.UNKNOWN_PARAM_FINDER_FAILURE, {
     metricId, error
   });

--- a/unicorn/app/browser/actions/ShowCreateModelDialog.js
+++ b/unicorn/app/browser/actions/ShowCreateModelDialog.js
@@ -28,6 +28,8 @@ import {ACTIONS} from '../lib/Constants';
  * @emits {SHOW_CREATE_MODEL_DIALOG}
  */
 export default function (actionContext, payload) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.SHOW_CREATE_MODEL_DIALOG);
+
   let {fileName, metricName} = payload;
   actionContext.dispatch(ACTIONS.SHOW_CREATE_MODEL_DIALOG, {
     fileName, metricName

--- a/unicorn/app/browser/actions/ShowFileDetails.js
+++ b/unicorn/app/browser/actions/ShowFileDetails.js
@@ -26,6 +26,8 @@ import {ACTIONS} from '../lib/Constants';
  * @emits {SHOW_FILE_DETAILS}
  */
 export default function (actionContext, file) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.SHOW_FILE_DETAILS);
+
   let db = actionContext.getDatabaseClient();
   db.getMetricsByFile(file.uid, (error, metrics) => {
     actionContext.dispatch(ACTIONS.SHOW_FILE_DETAILS, {

--- a/unicorn/app/browser/actions/ShowModel.js
+++ b/unicorn/app/browser/actions/ShowModel.js
@@ -30,6 +30,8 @@ import LoadMetricDataAction from './LoadMetricData';
  * @returns {Promise} - A Promise to be resolved with return value
  */
 export default function (actionContext, modelId) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.SHOW_MODEL);
+
   return Promise.all([
     actionContext.executeAction(LoadModelDataAction, modelId),
     actionContext.executeAction(LoadMetricDataAction, modelId)

--- a/unicorn/app/browser/actions/StartApplication.js
+++ b/unicorn/app/browser/actions/StartApplication.js
@@ -30,6 +30,8 @@ import ListModelsAction from '../actions/ListModels';
  * @returns {Promise} - A Promise to be resolved with return value
  */
 export default function (actionContext) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.START_APPLICATION);
+
   return new Promise((resolve, reject) => {
     // Allow stores to initialze
     resolve(actionContext.dispatch(ACTIONS.START_APPLICATION));

--- a/unicorn/app/browser/actions/StartModel.js
+++ b/unicorn/app/browser/actions/StartModel.js
@@ -30,6 +30,8 @@ import {promisify} from '../../common/common-utils';
  * @return {Promise}  Promise
  */
 export default function (actionContext, payload) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.START_MODEL);
+
   return new Promise((resolve, reject) => {
     let {aggOpts, inputOpts, metricId, modelOpts} = payload;
     let aggregated = (Object.keys(aggOpts).length >= 1);
@@ -58,6 +60,7 @@ export default function (actionContext, payload) {
       return resolve();
     })
     .catch((error) => {
+      actionContext.getGATracker().exception(ACTIONS.START_MODEL_FAILED);
       return reject(error);
     });
   });

--- a/unicorn/app/browser/actions/StartParamFinder.js
+++ b/unicorn/app/browser/actions/StartParamFinder.js
@@ -27,6 +27,8 @@ import {ACTIONS} from '../lib/Constants';
  * @TODO: {@ParamFinderService} should save `modelOpts` to database
  */
 export default function (actionContext, payload) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.START_PARAM_FINDER);
+
   let paramFinderClient = actionContext.getParamFinderClient();
   let {inputOpts, metricId} = payload;
 

--- a/unicorn/app/browser/actions/StopModel.js
+++ b/unicorn/app/browser/actions/StopModel.js
@@ -25,6 +25,8 @@ import {ACTIONS} from '../lib/Constants';
  * @emits {STOP_MODEL}
  */
 export default function (actionContext, modelId) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.STOP_MODEL);
+
   let modelClient = actionContext.getModelClient();
   modelClient.removeModel(modelId);
   actionContext.dispatch(ACTIONS.STOP_MODEL, modelId);

--- a/unicorn/app/browser/actions/StopParamFinder.js
+++ b/unicorn/app/browser/actions/StopParamFinder.js
@@ -25,6 +25,8 @@ import {ACTIONS} from '../lib/Constants';
  * @emits {STOP_PARAM_FINDER}
  */
 export default function (actionContext, metricId) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.STOP_PARAM_FINDER);
+
   let paramFinderClient = actionContext.getParamFinderClient();
   paramFinderClient.removeParamFinder(metricId);
   actionContext.dispatch(ACTIONS.STOP_PARAM_FINDER, metricId);

--- a/unicorn/app/browser/actions/ToggleAggregateData.js
+++ b/unicorn/app/browser/actions/ToggleAggregateData.js
@@ -27,5 +27,6 @@ import {ACTIONS} from '../lib/Constants';
  * @emits {TOGGLE_AGGREGATE_DATA}
  */
 export default function (actionContext, payload) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.TOGGLE_AGGREGATE_DATA);
   actionContext.dispatch(ACTIONS.TOGGLE_AGGREGATE_DATA, payload);
 }

--- a/unicorn/app/browser/entry.js
+++ b/unicorn/app/browser/entry.js
@@ -58,9 +58,11 @@ const {app} = require('electron').remote;
 
 const modelClient = new ModelClient();
 const paramFinderClient = new ParamFinderClient();
-const gaTracker = new GoogleAnalytics(config.get('GA_TRACKING_ID'),
+/* eslint-disable no-process-env */
+const gaTracker = new GoogleAnalytics(process.env.GA_TRACKING_ID,
                                       app.getName(), app.getVersion(),
-                                      config.get('NODE_ENV') === 'development');
+                                      process.env.NODE_ENV === 'development');
+/* eslint-enable no-process-env */
 
 /**
  * HTM Studio: Cross-platform Desktop Application to showcase basic HTM features

--- a/unicorn/app/browser/entry.js
+++ b/unicorn/app/browser/entry.js
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // global uncaught exception handler
   window.onerror = (message, file, line, col, error) => {
-    gaTracker.exception('Unknown Error', `Unknown Error: ${message}`);
+    gaTracker.exception('Unknown Error');
     dialog.showErrorBox('Unknown Error', `Unknown Error: ${message}`);
   };
 
@@ -154,7 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ReactDOM.render(contextEl, container);
     })
     .catch((error) => {
-      gaTracker.exception(error);
+      gaTracker.exception('Startup Error');
       console.log(error); // eslint-disable-line
       dialog.showErrorBox('Startup Error', `Startup Error: ${error}`);
     });

--- a/unicorn/app/browser/index.html
+++ b/unicorn/app/browser/index.html
@@ -4,6 +4,14 @@
     <meta charset="utf-8" />
     <title>HTM Studio | Numenta</title>
     <link rel="stylesheet" type="text/css" href="assets/styles/index.css" />
+    <script>
+      // Global error handler, catching errors with 'bundle.js'
+      window.onerror = (message, file, line, col, error) => {
+        alert(message);
+        // Quit application here. There is nothing left to do.
+        window.close();
+      };
+    </script>
   </head>
   <body>
     <div id="main">

--- a/unicorn/app/browser/lib/Analytics/GoogleAnalytics.js
+++ b/unicorn/app/browser/lib/Analytics/GoogleAnalytics.js
@@ -1,0 +1,295 @@
+// Copyright © 2016, Numenta, Inc.  Unless you have purchased from
+// Numenta, Inc. a separate commercial license for this software code, the
+// following terms and conditions apply:
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero Public License version 3 as published by the Free
+// Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero Public License for more details.
+//
+// You should have received a copy of the GNU Affero Public License along with
+// this program.  If not, see http://www.gnu.org/licenses.
+//
+// http://numenta.org/licenses/
+
+let uuid = require('node-uuid');
+
+// Googe analytics API version
+const API_VERSION = 1;
+
+// Googe analytics endpoint
+const API_ENDPOINT = 'https://www.google-analytics.com';
+
+// Googe analytics debug endpoint
+const API_DEBUG_ENDPOINT = 'https://www.google-analytics.com/debug';
+
+// Google Analytics accepts only 20 hits per batch request.
+const GA_BATCH_SIZE = 20;
+
+// Memory cache size
+const MAX_QUEUE_SIZE = 20;
+
+
+/**
+ * Get or create unique identifier representing the current user
+ * @return {string} UUID representing the Anonymous Client ID
+ */
+function _getUserId() {
+  // Get persisted User ID from local storage
+  let user = localStorage.getItem('ga:userId');
+  if (!user) {
+    user = uuid.v4();
+    localStorage.setItem('ga:userId', user);
+  }
+  return user;
+}
+
+
+/**
+ * Wraps Google analytics API
+ * See https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide
+ */
+export default class GoogleAnalytics {
+  /**
+   * Construct new Google Analytics API wrapper
+   * @param  {string} trackingId GoogleAnalytics tracing ID (i.e. UA-XXXXX)
+   * @param  {string} appName    Application Name (i.e. "HTM Studio")
+   * @param  {string} version    Application Verion (i.e. "1.0.0")
+   * @param  {boolean} [debug=false] Whether or not to use debug endpoint
+   */
+  constructor(trackingId, appName, version, debug) {
+    // Validate tracking Id
+    if (!trackingId) {
+      if (debug) {
+        // Use fake tracking id in development
+        trackingId = 'UA-DEBUG';
+      } else {
+        throw new Error('Invalid Google Analytics Tracking ID');
+      }
+    }
+
+    // Required parameters sent with every hit
+    this._header = `v=${API_VERSION}&tid=${trackingId}&cid=${_getUserId()}` +
+                   `&an=${appName}&av=${version}`;
+    // Memory queue
+    this._queue = [];
+
+    // Google Analytics endpoint used to send a single hit
+    this._endpointCollect = debug ? `${API_DEBUG_ENDPOINT}/collect`
+                                  : `${API_ENDPOINT}/collect`;
+    // Google Analytics endpoint used for sending hits in batch
+    this._endpointBatch = debug ? `${API_DEBUG_ENDPOINT}/collect`
+                                : `${API_ENDPOINT}/batch`;
+
+    // Initialize database
+    this._db = null;
+    new Promise((resolve, reject) => {
+      let request = indexedDB.open('analytics');
+      request.onsuccess = (event) => {
+        let db = event.target.result;
+        resolve(db);
+      }
+      request.onupgradeneeded = (event) => {
+        let db = event.target.result;
+        db.createObjectStore('pending', {autoIncrement: true});
+      }
+      request.onerror = (event) => {
+        reject(event);
+      }
+    })
+    .then((db) => {
+      this._db = db;
+      // synchronize any pending hits
+      this.synchronize();
+    });
+  }
+
+  /**
+   * Track page view
+   * @param {string} name    Page Name
+   * @param {string} [title] Page title
+   */
+  pageView(name, title) {
+    this._push(`${this._header}&t=pageView` +
+      `&dp=${name}&dt=${title || ''}`);
+  }
+
+  /**
+   * Track events
+   * @param  {string} category Event Category
+   * @param  {string} action   Event Action
+   * @param  {string} [label='']  Event label
+   * @param  {string} [value=0]  Specifies the event value. Values must be non-negative
+   */
+  event(category, action, label, value) {
+    this._push(`${this._header}&t=event` +
+      `&ec=${category}&ea=${action}&el=${label || ''}&ev=${value || 0}`);
+  }
+
+  /**
+   * Track exceptions
+   * @param  {string} description     Exception description (i.e. IOException)
+   * @param  {boolean} [fatal=false]  Exception is fatal?
+   */
+  exception(description, fatal) {
+    console.error(description); // eslint-disable-line
+    this._push(`${this._header}&t=exception` +
+      `&exd=${description}&exf=${fatal ? 1 : 0}`);
+  }
+
+  /**
+   * Upload pending hits to server
+   */
+  _upload() {
+    // Get all pending hits from database
+    this._getAllPening()
+      .then((records) => {
+        while (records.length > 0) {
+          // Batch at most GA_BATCH_SIZE hits per request
+          let batch = records.splice(0, GA_BATCH_SIZE);
+          let values = batch.map((item) => item.value);
+          let keys = batch.map((item) => item.key);
+          // Post cached hits and delete successfuly uploaded hits from database
+          this._post(values)
+            .then(() => this._deletePending(keys))
+            .catch((error) => this.exception(error));
+        }
+      });
+  }
+
+  /**
+   * Synchronize local data with server.
+   * Keep pending hits in local database until they are successfuly uploaded
+   */
+  synchronize() {
+    // Empty memory queue
+    let hits = this._queue.splice(0);
+    // Persist hits before uploading to server in case of network error
+    this._savePending(hits)
+        .then(() => this._upload())
+        .catch((error) => this.exception(error));
+  }
+
+  /**
+   * Push new event to queue synchronizing with GA server when necessary
+   * @param  {string} payload Single Google Analytics payload
+   */
+  _push(payload) {
+    this._queue.push(encodeURI(payload));
+    if (this._queue.length >= MAX_QUEUE_SIZE) {
+      this.synchronize();
+    }
+  }
+
+  /**
+   * Save pending hits to database
+   * @param  {array} hits Array of hits to save
+   * @return {Promise} Promise wrapping database transaction.
+   *                           `resolve` : transaction completed successfuly
+   *                           `reject`: transaction failed
+   */
+  _savePending(hits) {
+    return new Promise((resolve, reject) => {
+      if (hits.length === 0) {
+        resolve(); // Nothing to add
+      } else if (this._db) {
+        // Add all hits in a single transaction
+        let transaction = this._db.transaction(['pending'], 'readwrite');
+        transaction.oncomplete = resolve;
+        transaction.onerror = reject;
+        let store = transaction.objectStore('pending');
+        hits.forEach((item) => store.add(item));
+      } else {
+        reject(new Error('Unable to open database'));
+      }
+    });
+  }
+
+  /**
+   * Get all pending hits stored in the database
+   * @return {Promise} Promise wrapping database transaction.
+   *                           `resolve` : With all pending hits on success
+   *                           `reject`: transaction failed
+   */
+  _getAllPening() {
+    return new Promise((resolve, reject) => {
+      if (this._db) {
+        // Get all hits from database
+        let hits = [];
+        let transaction = this._db.transaction(['pending'], 'readonly');
+        transaction.onerror = (error) => {
+          reject(error);
+        };
+        let store = transaction.objectStore('pending');
+        let request = store.openCursor();
+        request.onsuccess = (event) => {
+          let cursor = event.target.result;
+          if (cursor) {
+            hits.push({key: cursor.key, value: cursor.value});
+            cursor.continue();
+          } else {
+            resolve(hits);
+          }
+        };
+        request.onerror = (error) => {
+          reject(error);
+        };
+      } else {
+        reject(new Error('Unable to open database'));
+      }
+    });
+  }
+
+  /**
+   * _deletePending pending hits from database
+   * @param  {array} hits Array of hits to delete
+   * @return {Promise} Promise wrapping database transaction.
+   *                           `resolve` : transaction completed successfuly
+   *                           `reject`: transaction failed
+   */
+  _deletePending(hits) {
+    return new Promise((resolve, reject) => {
+      if (hits.length === 0) {
+        resolve(); // Nothing to delete
+      } else if (this._db) {
+        // Delete all hits in a single transaction
+        let transaction = this._db.transaction(['pending'], 'readwrite');
+        transaction.oncomplete = resolve;
+        transaction.onerror = reject;
+        let store = transaction.objectStore('pending');
+        hits.forEach((item) => store.delete(item));
+      } else {
+        reject(new Error('Unable to open database'));
+      }
+    });
+  }
+
+  /**
+   * Post paylod to Google analytics server
+   * @param {array} payload Array of 'hits' to send
+   * @return {Promise}  Returns promise that could be used to check for errors
+   * @see https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+   */
+  _post(payload) {
+    if (payload.length > 0) {
+      let url;
+      // Check if sending batched hits
+      if (payload.length === 1) {
+        url = this._endpointCollect;
+      } else {
+        url = this._endpointBatch;
+      }
+      return fetch(url, {
+        method: 'POST',
+        body: payload.join('\n'),
+        mode: 'no-cors'
+      });
+    }
+    // Nothing to send
+    return Promise.resolve();
+  }
+}

--- a/unicorn/app/browser/lib/Analytics/GoogleAnalytics.js
+++ b/unicorn/app/browser/lib/Analytics/GoogleAnalytics.js
@@ -142,10 +142,11 @@ export default class GoogleAnalytics {
 
   /**
    * Upload pending hits to server
+   * @return {Promise}  Returns promise that could be used to check for errors
    */
   _upload() {
     // Get all pending hits from database
-    this._getAllPening()
+    return this._getAllPening()
       .then((records) => {
         while (records.length > 0) {
           // Batch at most GA_BATCH_SIZE hits per request
@@ -153,9 +154,7 @@ export default class GoogleAnalytics {
           let values = batch.map((item) => item.value);
           let keys = batch.map((item) => item.key);
           // Post cached hits and delete successfuly uploaded hits from database
-          this._post(values)
-            .then(() => this._deletePending(keys))
-            .catch((error) => this.exception(error));
+          this._post(values).then(() => this._deletePending(keys));
         }
       });
   }
@@ -163,14 +162,13 @@ export default class GoogleAnalytics {
   /**
    * Synchronize local data with server.
    * Keep pending hits in local database until they are successfuly uploaded
+   * @return {Promise}  Returns promise that could be used to check for errors
    */
   synchronize() {
     // Empty memory queue
     let hits = this._queue.splice(0);
     // Persist hits before uploading to server in case of network error
-    this._savePending(hits)
-        .then(() => this._upload())
-        .catch((error) => this.exception(error));
+    return this._savePending(hits).then(() => this._upload());
   }
 
   /**

--- a/unicorn/app/browser/lib/Fluxible/HTMStudioPlugin.js
+++ b/unicorn/app/browser/lib/Fluxible/HTMStudioPlugin.js
@@ -27,7 +27,7 @@ export default {
   plugContext(options, context, app) {
     let {
       configClient, loggerClient, databaseClient, fileClient, modelClient,
-      paramFinderClient
+      paramFinderClient, gaTracker
     } = options;
 
     return {
@@ -50,6 +50,9 @@ export default {
         actionContext.getParamFinderClient = function () {
           return paramFinderClient;
         };
+        actionContext.getGATracker = function () {
+          return gaTracker;
+        };
       },
 
       plugComponentContext(componentContext, context, app) {
@@ -71,6 +74,9 @@ export default {
         componentContext.getParamFinderClient = function () {
           return paramFinderClient;
         };
+        componentContext.getGATracker = function () {
+          return gaTracker;
+        };
       },
 
       plugStoreContext(storeContext, context, app) {
@@ -91,6 +97,9 @@ export default {
         };
         storeContext.getParamFinderClient = function () {
           return paramFinderClient;
+        };
+        storeContext.getGATracker = function () {
+          return gaTracker;
         };
       }
     };

--- a/unicorn/app/package.json
+++ b/unicorn/app/package.json
@@ -74,6 +74,7 @@
     "lodash": "^4.11.2",
     "material-ui": "0.14.4",
     "moment": "2.11.2",
+    "node-uuid": "1.4.1",
     "nconf": "0.8.4",
     "react": "0.14.7",
     "react-addons-create-fragment": "0.14.7",

--- a/unicorn/webpack.config.babel.js
+++ b/unicorn/webpack.config.babel.js
@@ -15,14 +15,23 @@
 //
 // http://numenta.org/licenses/
 
+/* eslint-disable no-process-env */
+
+const webpack = require('webpack');
+
 // Get current environment ('development' or 'production')
-const DEVELOPMENT = process.env.NODE_ENV === 'development'; // eslint-disable-line
+const DEVELOPMENT = process.env.NODE_ENV === 'development';
 
 /**
  * WebPack ES6 Config File
  */
 export default {
   bail: true,
+  plugins: [
+    new webpack.EnvironmentPlugin([
+      'NODE_ENV', 'GA_TRACKING_ID'
+    ])
+  ],
   devtool: DEVELOPMENT ? 'source-map' : null,
   entry: ['babel-polyfill', './app/browser/entry'],
   module: {


### PR DESCRIPTION
Use "Google Analytics" to collect usage data, currently tracking most 'React' actions.

- Based on Google Analytics [Measurement Protocol]( https://developers.google.com/analytics/devguides/collection/protocol/v1/). 
- Works offline by caching events in the browser's [indexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) store.
- In development mode the events are not stored but can be viewed in the debugger
- In production mode a real Google Analytics tracking ID must be provided, see `README`.

@marionleborgne Please Review

CC: @vitaly-krugl 