### PR TITLE
UNI-481 Freeze nupic at 0.5.0 via unicorn/py/requirements.txt and automate nupic.core commitish

### DIFF
--- a/unicorn/py/requirements.txt
+++ b/unicorn/py/requirements.txt
@@ -2,4 +2,4 @@ python-dateutil==2.1
 validictory==0.9.1
 
 # NuPIC HTM. Use version installed with 'portable_python'
-nupic
+nupic==0.5.0

--- a/unicorn/scripts/OSX/build-python.sh
+++ b/unicorn/scripts/OSX/build-python.sh
@@ -26,6 +26,7 @@
 # nupic and nupic.bindings installed.
 
 set -o errexit
+set -o pipefail
 set -o xtrace
 
 OSX_VERSION=$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')
@@ -34,8 +35,10 @@ PYTHON_SH="Miniconda-latest-MacOSX-x86_64.sh"
 CAPNP="capnproto-c++-0.5.3"
 WORKING_DIR=${PWD}
 SCRIPT_PATH=$(cd "$(dirname "$0")"; pwd)
+UNICORN_BACKEND_REQUIREMENTS_TXT=${SCRIPT_PATH}/../../py/requirements.txt
 NUPIC_CORE=${WORKING_DIR}/nupic.core
 NUPIC=${WORKING_DIR}/nupic
+NUPIC_MODULES=${NUPIC}/.nupic_modules
 PREFIX=${WORKING_DIR}/portable_python
 PATH_VALUE=${PREFIX}/bin:${PREFIX}/include
 
@@ -81,8 +84,22 @@ pushd $CAPNP
 make -j6 check && make install
 popd
 
-echo "==> Cloning nupic.core ..."
+echo "==> Getting nupic version from ${UNICORN_BACKEND_REQUIREMENTS_TXT}..."
+NUPIC_VER=$(grep "^nupic==" "${UNICORN_BACKEND_REQUIREMENTS_TXT}" | cut -d "=" -f 3)
+echo "Got nupic version to install: ${NUPIC_VER}"
+
+# Next, get nupic of the desired version and get the commitish of the matching nupic.core
+echo "==> Cloning nupic at version ${NUPIC_VER}..."
+git clone https://github.com/numenta/nupic.git
+(cd "${NUPIC}" && git reset --hard "${NUPIC_VER}")
+
+echo "==> Getting nupic.core committish from ${NUPIC_MODULES}"
+NUPIC_CORE_COMMITISH=$(grep "^NUPIC_CORE_COMMITISH =" "${NUPIC_MODULES}" | cut -d "'" -f 2)
+echo "Got nupic.core commitish: ${NUPIC_CORE_COMMITISH}"
+
+echo "==> Cloning nupic.core at commitish ${NUPIC_CORE_COMMITISH} ..."
 git clone https://github.com/numenta/nupic.core.git
+(cd "${NUPIC_CORE}" && git reset --hard "${NUPIC_CORE_COMMITISH}")
 
 echo "==> Installing nupic.core requirements ..."
 rm -rf $NUPIC_CORE/build
@@ -109,9 +126,6 @@ pushd $NUPIC_CORE/bindings/py
 export ARCHFLAGS="-arch x86_64"
 $PREFIX/bin/python setup.py install
 popd
-
-echo "==> Cloning nupic ..."
-git clone https://github.com/numenta/nupic.git
 
 echo "==> Installing nupic ..."
 pushd $NUPIC


### PR DESCRIPTION
UNI-481 Freeze nupic at 0.5.0 via unicorn/py/requirements.txt
UNI-481 Modify unicorn/scripts/OSX/build-python.sh to pick up nupic version from unicorn/py/requirements.txt, then get matching nupic.core commitish from the nupic sources of the required version.