### PR TITLE
Show metric name in hover text, not just 'Value:'

### DIFF
--- a/unicorn/app/browser/components/Chart.jsx
+++ b/unicorn/app/browser/components/Chart.jsx
@@ -542,7 +542,9 @@ export default class Chart extends React.Component {
 
     keyvalue.append('span')
       .style('font-weight', 'bold')
-      .text(secondary ? 'Non-aggregated value: ' : 'Value: ');
+      .text((secondary || !this.props.model.aggregated)
+            ? `${this.props.metric.name}: `
+            : `Aggregated ${this.props.metric.name}: `);
 
     keyvalue.append('span')
       .text(formatDisplayValue(value));
@@ -721,6 +723,12 @@ export default class Chart extends React.Component {
 
     this._onWindowResizeWrapper = () => this._onWindowResize();
     window.addEventListener('resize', this._onWindowResizeWrapper);
+
+    if (this.props.modelData.length > 0 && !this.props.model.active) {
+      // This model already ran, but updates might still happen via
+      // the aggregated / non-aggregated checkbox.
+      this._jumpToNewResults = false;
+    }
 
     let dateWindow;
     if (metric.dateWindow) {


### PR DESCRIPTION
This change also fixes the following bug:

1. Unhide a model that has finished running
2. Click "show non-aggregated data"

RESULT:
The selected dateWindow jumps to the end

@marionleborgne Note the label behavior. Some example text is:

![image](https://cloud.githubusercontent.com/assets/364113/15586850/647169b6-233b-11e6-9faf-7c1e0425de83.png)

![image](https://cloud.githubusercontent.com/assets/364113/15586866/6e990a98-233b-11e6-9a29-562530d723ac.png)

![image](https://cloud.githubusercontent.com/assets/364113/15586837/559f4fac-233b-11e6-8a04-4fd0f750ea0c.png)

![image](https://cloud.githubusercontent.com/assets/364113/15586821/348f802a-233b-11e6-85ac-d2d24374c9dd.png)

Let me know what you think.