### PR TITLE
UNI-502: Add script to remove cached `portable_python`

### DIFF
--- a/unicorn/README.md
+++ b/unicorn/README.md
@@ -262,6 +262,8 @@ Here are the `npm` scripts available via `npm run <script-name>`. Please see
   * `clean:db:osx`: Delete database files (OSX)
   * `clean:docs`: Delete documentation
   * `clean:npm`: Delete `npm` installed packages
+  * `clean:portable_python:osx`: Delete cached `portable_python` package (OSX)
+  * `clean:portable_python:win`: Delete cached `portable_python` package (Windows)
   * `clean:python`: Delete `python` build artifacts
   * `clean:webpack`: Clean compiled/packaged JS code
 * `dev`: Launch Desktop application

--- a/unicorn/package.json
+++ b/unicorn/package.json
@@ -32,6 +32,8 @@
     "clean:docs": "rimraf docs/",
     "clean:coverage": "rimraf coverage/",
     "clean:npm": "rimraf app/node_modules/ && rimraf node_modules/ && npm cache clean",
+    "clean:portable_python:osx": "rimraf scripts/OSX/portable_python.tar.gz",
+    "clean:portable_python:win": "rimraf scripts/Windows64/portable_python.tar.gz",
     "clean:python": "rimraf py/build && rimraf py/dist && rimraf py/*.egg-info",
     "clean:webpack": "rimraf app/browser/assets/bundle",
     "electron": "NODE_ENV=development electron app",


### PR DESCRIPTION
@marionleborgne per your request.
To remove your cached version of `portable_python` run the following command:
```shel
npm run clean:portable_python:osx
```
This will force the new version of python to be downloaded from the latest successful build like before.