### PR TITLE
UNI-518: Fix error messages when creating models

### DIFF
--- a/unicorn/app/browser/actions/ModelError.js
+++ b/unicorn/app/browser/actions/ModelError.js
@@ -22,8 +22,8 @@ import {ACTIONS} from '../lib/Constants';
  * Dispatches `model_runner` errors
  * @param {FluxActionContext} actionContext FluxibleContext
  * @param {object} payload       Error payload
- * @param {string} payload.modelId The model that generate the error
  * @param {string} payload.command The command that generate the error
+ * @param {string} payload.modelId The model that generate the error
  * @param {string} payload.error The error description
  * @emits {START_MODEL_FAILED}
  * @emits {STOP_MODEL_FAILED}

--- a/unicorn/app/browser/actions/ParamFinderError.js
+++ b/unicorn/app/browser/actions/ParamFinderError.js
@@ -22,8 +22,8 @@ import {ACTIONS} from '../lib/Constants';
  * Dispatches `param_finder` errors
  * @param {FluxibleContext} actionContext  FluxibleContext
  * @param {object} payload       Error payload
- * @param {string} payload.metricId The metric that generate the error
  * @param {string} payload.command The command that generate the error
+ * @param {string} payload.metricId The metric that generate the error
  * @param {string} payload.error The error description
  * @emits {START_PARAM_FINDER_FAILED}
  * @emits {STOP_PARAM_FINDER_FAILED}

--- a/unicorn/app/browser/lib/HTMStudio/ModelClient.js
+++ b/unicorn/app/browser/lib/HTMStudio/ModelClient.js
@@ -64,7 +64,7 @@ export default class ModelClient {
         this._context.executeAction(NotifyNewModelResultsAction, modelId);
       } else if (command === 'error') {
         let {error, ipcevent} = payload;
-        this._handleIPCError(modelId, error, ipcevent);
+        this._handleIPCError(error, ipcevent);
       } else if (command === 'close') {
         this._handleCloseModel(modelId, payload);
       } else {
@@ -91,8 +91,8 @@ export default class ModelClient {
   _handleCloseModel(modelId, error) {
     if (error !== 0) {
       this._context.executeAction(ModelErrorAction, {
-        modelId,
         command: 'close',
+        modelId,
         error: `Error closing model ${error}`
       });
     } else {

--- a/unicorn/app/browser/lib/HTMStudio/ParamFinderClient.js
+++ b/unicorn/app/browser/lib/HTMStudio/ParamFinderClient.js
@@ -63,7 +63,7 @@ export default class ParamFinderClient {
         setTimeout(() => this._handleParamFinderData(metricId, payload));
       } else if (command === 'error') {
         let {error, ipcevent} = payload;
-        setTimeout(() => this._handleIPCError(metricId, error, ipcevent));
+        setTimeout(() => this._handleIPCError(error, ipcevent));
       } else if (command === 'close') {
         setTimeout(() => this._handleCloseParamFinder(metricId ,payload));
       } else {
@@ -91,8 +91,8 @@ export default class ParamFinderClient {
   _handleCloseParamFinder(metricId, error) {
     if (error !== 0) {
       this._context.executeAction(ParamFinderErrorAction, {
-        metricId,
         command: 'close',
+        metricId,
         error: `Error closing param finder ${error}`
       });
     } else {


### PR DESCRIPTION
@marionleborgne This PR fixes messages being logged as  'UNKNOWN_MODEL_ERROR' and 'UNKOWN_PARAM_FINDER_ERROR' when creating the models. Now it logs the real error name.
We should fix the real error on a separate PR.