### PR TITLE
UNI-495 Enable YYYY-MM-DD and YYYY/MM/DD date formats.

### DIFF
--- a/unicorn/app/config/momentjs_to_datetime_strptime.json
+++ b/unicorn/app/config/momentjs_to_datetime_strptime.json
@@ -47,7 +47,8 @@
       "YYYY-MM-DD HH:mmZ": "%Y-%m-%d %H:%M%z",
       "YYYY-MM-DD HH:mm": "%Y-%m-%d %H:%M",
       "YYYY-MM-DD HHZ": "%Y-%m-%d %H%z",
-      "YYYY-MM-DD HH": "%Y-%m-%d %H"
+      "YYYY-MM-DD HH": "%Y-%m-%d %H",
+      "YYYY-MM-DD": "%Y-%m-%d"
     }
   },
   {
@@ -64,9 +65,10 @@
       "YYYY/MM/DD HH:mmZ": "%Y/%m/%d %H:%M%z",
       "YYYY/MM/DD HH:mm": "%Y/%m/%d %H:%M",
       "YYYY/MM/DD HHZ": "%Y/%m/%d %H%z",
-      "YYYY/MM/DD HH": "%Y/%m/%d %H"
+      "YYYY/MM/DD HH": "%Y/%m/%d %H",
+      "YYYY/MM/DD": "%Y/%m/%d"
     }
-  },  
+  },
   {
     "category": "US Date, 12h AM/PM time",
     "mappings": {


### PR DESCRIPTION
This was already being tested in unicorn_backed, but none of it is tested on the JS side.

Marion recommended to defer JS-side tests, since this is so well tested in unicorn_backend, in favor of higher-priority issues.