### PR TITLE
Bugfix: We're cancelling model data queries too often

### DIFF
--- a/unicorn/app/browser/actions/StopApplication.js
+++ b/unicorn/app/browser/actions/StopApplication.js
@@ -1,0 +1,29 @@
+// Copyright © 2016, Numenta, Inc. Unless you have purchased from
+// Numenta, Inc. a separate commercial license for this software code, the
+// following terms and conditions apply:
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero Public License version 3 as published by the
+// Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero Public License for more details.
+//
+// You should have received a copy of the GNU Affero Public License along with
+// this program. If not, see http://www.gnu.org/licenses.
+//
+// http://numenta.org/licenses/
+
+import {ACTIONS} from '../lib/Constants';
+
+
+/**
+ * Close application
+ * @param {FluxibleContext} actionContext - Fluxible action context object
+ * @emits {STOP_APPLICATION}
+ */
+export default function (actionContext) {
+  actionContext.getGATracker().event('ACTION', ACTIONS.STOP_APPLICATION);
+  actionContext.dispatch(ACTIONS.STOP_APPLICATION);
+}

--- a/unicorn/app/browser/entry.js
+++ b/unicorn/app/browser/entry.js
@@ -50,6 +50,7 @@ import ModelDataStore from './stores/ModelDataStore';
 import ModelStore from './stores/ModelStore';
 import ParamFinderClient from './lib/HTMStudio/ParamFinderClient';
 import StartApplicationAction from './actions/StartApplication';
+import StopApplicationAction from './actions/StopApplication';
 import {trims} from '../common/common-utils';
 
 const dialog = remote.require('dialog');
@@ -163,6 +164,8 @@ document.addEventListener('DOMContentLoaded', () => {
         type: 'question'
       });
       if (!cancel) {
+        context.executeAction(StopApplicationAction);
+
         // stop all active models before quitting
         active.forEach((model) => {
           modelClient.removeModel(model.modelId);

--- a/unicorn/app/browser/lib/Constants.js
+++ b/unicorn/app/browser/lib/Constants.js
@@ -24,6 +24,7 @@ Object.assign(module.exports, CommonConstants);
  *
  * - Application
  *  - START_APPLICATION: {@StartApplication}
+ *  - STOP_APPLICATION
  *
  * - File
  *  - DELETE_FILE: {@link DeleteFile}
@@ -101,6 +102,7 @@ Object.assign(module.exports, CommonConstants);
 export const ACTIONS = Object.freeze({
   // Application
   START_APPLICATION: 'START_APPLICATION',
+  STOP_APPLICATION: 'STOP_APPLICATION',
 
   // File
   DELETE_FILE: 'DELETE_FILE',

--- a/unicorn/app/browser/stores/ModelDataStore.js
+++ b/unicorn/app/browser/stores/ModelDataStore.js
@@ -37,7 +37,7 @@ export default class ModelDataStore extends BaseStore {
       NOTIFY_NEW_MODEL_RESULTS: '_handleNewModelResults',
       LOAD_MODEL_DATA: '_handleLoadModelData',
       HIDE_MODEL: '_handleHideModel',
-      STOP_MODEL: '_handleStopModel',
+      STOP_APPLICATION: '_handleStopApplication',
       DELETE_MODEL: '_handleDeleteModel'
     };
   }
@@ -135,14 +135,14 @@ export default class ModelDataStore extends BaseStore {
   }
 
   /**
-   * Stop model.
-   * @param {string} modelId - Model to stop
+   * Close application
    */
-  _handleStopModel(modelId) {
-    let model = this._models.get(modelId);
-    if (model && model.fetchTimeoutId !== null) {
-      clearTimeout(model.fetchTimeoutId);
-      model.fetchTimeoutId = null;
+  _handleStopApplication() {
+    for (let model of this._models.values()) {
+      if (model.fetchTimeoutId !== null) {
+        clearTimeout(model.fetchTimeoutId);
+        model.fetchTimeoutId = null;
+      }
     }
   }
 


### PR DESCRIPTION
The stop model action gets called whenever a model ends, so it's the wrong place to cancel any pending queries.

With super-small datasets, we were seeing 0 results appear.

Thanks @marionleborgne for catching this.