### PR TITLE
UNI-558: Make app single instance

### DIFF
--- a/unicorn/app/main/index.js
+++ b/unicorn/app/main/index.js
@@ -136,6 +136,20 @@ app.on('window-all-closed', () => {
   app.quit();
 });
 
+const shouldQuit = app.makeSingleInstance((commandLine, workingDirectory) => {
+  // Someone tried to run a second instance, we should focus our window.
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore();
+    }
+    mainWindow.focus();
+  }
+});
+
+if (shouldQuit) {
+  app.quit();
+}
+
 // Electron finished init and ready to create browser window
 app.on('ready', () => {
   // set main menu


### PR DESCRIPTION
@marionleborgne this should make the app single instance on Windows and Mac preventing database lock errors when trying to relaunch the app.

CC: @cbaranski 