### PR TITLE
UNI-578 Handle rapid checkbox clicking

### DIFF
--- a/unicorn/app/browser/stores/ModelDataStore.js
+++ b/unicorn/app/browser/stores/ModelDataStore.js
@@ -92,7 +92,12 @@ export default class ModelDataStore extends BaseStore {
       // In this case, we've already stored this model.
       this._fetchNewResultsSoon(modelId);
     } else {
-      throw new Error('Listen for new results before querying.', modelId);
+      // Normally this means there's a bug in the code.
+      //
+      // This can also happen when LOAD_MODEL_DATA and HIDE_MODEL events occur
+      // in a strange order, e.g. when you rapidly show and hide a model while
+      // another model is running. So just warn, don't throw an exception.
+      console.warn(`Showed a model without first listening for new results. ${modelId}`); // eslint-disable-line
     }
 
     this.emitChange();

--- a/unicorn/app/browser/stores/ModelStore.js
+++ b/unicorn/app/browser/stores/ModelStore.js
@@ -142,8 +142,11 @@ export default class ModelStore extends BaseStore {
    */
   _showModel(modelId) {
     let model = this._models.get(modelId);
-    if (model) {
+    if (model && !model.visible) {
       model.visible = true;
+
+      // Make sure multiple SHOW_MODEL events don't cause the model to get added
+      // to this list twice. Check whether the model is visible first.
       this._visibleModelStack.unshift(model);
       this.emitChange();
     }


### PR DESCRIPTION
This change fixes two similar bugs. When you rapidly click the show/hide checkbox, events can happen in an unexpected order. Now we detect this scenario in ModelDataStore and ModelStore.

@marionleborgne @lscheinkman 