### PR TITLE
updated app description

### DIFF
--- a/unicorn/app/package.json
+++ b/unicorn/app/package.json
@@ -2,7 +2,7 @@
   "name": "htmstudio",
   "productName": "HTM Studio",
   "version": "0.0.9",
-  "description": "Numenta HTM Studio Cross-platform HTM Example Desktop Application",
+  "description": "HTM Studio",
   "main": "main/loader.js",
   "private": true,
   "homepage": "http://numenta.com",


### PR DESCRIPTION
@cbaranski made the description "HTM Studio". Instead of "Numenta HTM Studio Cross-platform HTM Example Desktop Application" 