### PR TITLE
UNI-583 When a point has gaps on both sides, show a dot

### DIFF
--- a/unicorn/app/browser/components/Chart.jsx
+++ b/unicorn/app/browser/components/Chart.jsx
@@ -263,7 +263,7 @@ export default class Chart extends React.Component {
   }
 
   _yScaleUpdate() {
-    let paddingPx = 2;
+    let paddingPx = 3;
     let height = this._styles.root.height - RANGE_SELECTOR_HEIGHT - 3;
     let range = [height - paddingPx, paddingPx];
 

--- a/unicorn/app/browser/components/Chart.jsx
+++ b/unicorn/app/browser/components/Chart.jsx
@@ -826,7 +826,8 @@ export default class Chart extends React.Component {
       valueRange: this._yScale.domain(),
       axisLineColor: muiTheme.rawTheme.palette.accent4Color,
       connectSeparatedPoints: true,  // required for raw+agg overlay
-      highlightCircleSize: 0,
+      highlightCircleSize: 3, // also configures the 'point between gaps' size
+      drawHighlightPointCallback: () => {}, // disable highlight points
       interactionModel: {}, // we handle all of the interaction
       showLabelsOnHighlight: false,
       labelsDiv: document.createElement('div'), // put its labels into the abyss


### PR DESCRIPTION
This used to work. It broke when I made the big d3 change, commit 48799da40e296b4bec4507c9127e622b2fa8f0d0

Dygraphs uses the "highlightCircleSize" parameter to choose the size of these dots. We no longer use Dygraphs highlight dots, so I disabled them. This had unintended consequences.

The fix: give the circles some size, and disable them via a callback.

@marionleborgne 