### PR TITLE
Make anomalyScore type check more general and add type of the offending object to the assertion message when typecheck of anomaly score fails

### DIFF
--- a/htmengine/htmengine/model_swapper/model_swapper_interface.py
+++ b/htmengine/htmengine/model_swapper/model_swapper_interface.py
@@ -70,6 +70,7 @@ App layer reads results::
 from collections import namedtuple
 import datetime
 import json
+import numbers
 import time
 import types
 import uuid
@@ -384,7 +385,7 @@ class ModelInferenceResult(_ModelRequestResultBase):
     :param rowID: rowID id of the corresponding input record
     :param status: integer; 0 (zero) means success, otherwise it's an error code
       from htmengine.htmengineerno
-    :param anomalyScore: the Anomaly Score floating point value if status is 0
+    :param anomalyScore: the Anomaly Score numerical value if status is 0
       (zero), omit otherwise
     :param errorMessage: error message if status is non-zero, omit otherwise
     """
@@ -392,9 +393,9 @@ class ModelInferenceResult(_ModelRequestResultBase):
       "Expected int or long as status, but got: " + repr(status))
 
     if status == 0:
-      assert isinstance(anomalyScore, (int, long, float)), (
-        "Expected numeric anomaly score with status=0, but got: " +
-        repr(anomalyScore))
+      assert isinstance(anomalyScore, numbers.Number), (
+        "Expected numeric anomaly score with status=0, but got: {} ({})".format(
+          repr(anomalyScore), type(anomalyScore)))
       assert errorMessage is None, (
         "Unexpected errorMessage with status=0: " + repr(errorMessage))
     else:

--- a/htmengine/tests/unit/model_swapper/model_swapper_interface_test.py
+++ b/htmengine/tests/unit/model_swapper/model_swapper_interface_test.py
@@ -27,6 +27,7 @@ Unit tests for the model_swapper_interface classes
 import copy
 import datetime
 import json
+import numpy
 import os
 import unittest
 import uuid
@@ -339,19 +340,25 @@ class ModelInferenceResultTestCase(unittest.TestCase):
   """
 
 
-  def testModelInferenceResultConstructorWithSuccessStatus(self):
+  def testModelInferenceResultWithAcceptableAnomalyScoreTypes(self):
     rowID = 1
     status = 0
-    anomalyScore = 1.95
-    inferenceResult = ModelInferenceResult(rowID=rowID, status=status,
-      anomalyScore=anomalyScore)
-    self.assertEqual(inferenceResult.rowID, rowID)
-    self.assertEqual(inferenceResult.status, status)
-    self.assertEqual(inferenceResult.anomalyScore, anomalyScore)
-    self.assertIsNone(inferenceResult.errorMessage)
-    self.assertIn("ModelInferenceResult<", str(inferenceResult))
-    self.assertIn("ModelInferenceResult<", repr(inferenceResult))
-    self.assertIn("anomalyScore", repr(inferenceResult))
+    scoreValue = 1.95
+    for anomalyScore in [int(scoreValue),
+                         long(scoreValue),
+                         float(scoreValue),
+                         numpy.float(scoreValue),
+                         numpy.float32(scoreValue)]:
+      result = ModelInferenceResult(rowID=rowID, status=status,
+                                    anomalyScore=anomalyScore)
+      self.assertEqual(result.rowID, rowID)
+      self.assertEqual(result.status, status)
+      self.assertEqual(result.anomalyScore, anomalyScore)
+      self.assertIsNone(result.errorMessage)
+      self.assertIn("ModelInferenceResult<", str(result))
+      self.assertIn("ModelInferenceResult<", repr(result))
+      self.assertIn("anomalyScore", repr(result))
+
 
 
   def testModelInferenceResultConstructorWithErrorStatus(self):


### PR DESCRIPTION
Fixes #891 

The goal of this PR is narrowly focused on improving the existing argument check and providing slightly more diagnostic info when the check fails, such as the initial failure described in https://discourse.numenta.org/t/my-installation-suddenly-failed-with-asertionerror-message/1389.