### PR TITLE
Cast anomalyScore to float to work around json serialization issue

### DIFF
--- a/htmengine/htmengine/model_swapper/model_swapper_interface.py
+++ b/htmengine/htmengine/model_swapper/model_swapper_interface.py
@@ -431,6 +431,8 @@ class ModelInferenceResult(_ModelRequestResultBase):
 
     self.rowID = rowID
     self.status = status
+    # Cast to float to work around TypeError during json serialization when
+    # anomaly score is numpy.float16 or numpy.float32
     self.anomalyScore = float(anomalyScore)
     self.multiStepBestPredictions = multiStepBestPredictions
     self.errorMessage = errorMessage

--- a/htmengine/htmengine/model_swapper/model_swapper_interface.py
+++ b/htmengine/htmengine/model_swapper/model_swapper_interface.py
@@ -433,7 +433,8 @@ class ModelInferenceResult(_ModelRequestResultBase):
     self.status = status
     # Cast to float to work around TypeError during json serialization when
     # anomaly score is numpy.float16 or numpy.float32
-    self.anomalyScore = float(anomalyScore)
+    self.anomalyScore = (float(anomalyScore)
+                         if anomalyScore is not None else None)
     self.multiStepBestPredictions = multiStepBestPredictions
     self.errorMessage = errorMessage
 

--- a/htmengine/htmengine/model_swapper/model_swapper_interface.py
+++ b/htmengine/htmengine/model_swapper/model_swapper_interface.py
@@ -431,7 +431,7 @@ class ModelInferenceResult(_ModelRequestResultBase):
 
     self.rowID = rowID
     self.status = status
-    self.anomalyScore = anomalyScore
+    self.anomalyScore = float(anomalyScore)
     self.multiStepBestPredictions = multiStepBestPredictions
     self.errorMessage = errorMessage
 


### PR DESCRIPTION
Reported by licensee and in https://discourse.numenta.org/t/problem-running-htmengine-skeleton-app/1403.

The issue occurs when the resulting anomalyScore is of type `numpy.float32` or `numpy.float16`. E.g.,
```
>>> json.dumps(numpy.float(1.0))
'1.0'
>>> json.dumps(numpy.float32(1.0))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: 1.0 is not JSON serializable
>>> json.dumps(numpy.float16(1.0))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: 1.0 is not JSON serializable
>>> json.dumps(numpy.float64(1.0))
'1.0'
```