### PR TITLE
Remove "under heavy development" warning

### DIFF
--- a/unicorn/README.md
+++ b/unicorn/README.md
@@ -3,8 +3,6 @@
 > Cross-platform Desktop Application to demonstrate basic HTM functionality to
 > users using their own data files.
 
-**WARNING! UNDER HEAVY DEVELOPMENT.**
-
 
 ## License
 


### PR DESCRIPTION
Small PR to remove the obsolete warning in the README.